### PR TITLE
Friends of Convex swag claim app on Convex static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 This is a [Next.js](https://nextjs.org) project with OpenAI Voice Agents integration, featuring a collaborative drawing canvas and voice assistant.
 
+> **Also in this repo:** [`swag/`](./swag) is a standalone Friends of Convex swag
+> giveaway app. It has its own Convex deployment and its own dependencies, so it
+> does not affect this project. See [swag/README.md](./swag/README.md).
+
 ## Features
 
 - 🎨 **Excalidraw Canvas**: Collaborative drawing and diagramming

--- a/swag/.env.example
+++ b/swag/.env.example
@@ -5,12 +5,28 @@
 # Everything else lives on the Convex deployment, not in this file.
 # Set those with the CLI:
 #
-#   npx convex env set ADMIN_KEY        "a-long-random-string"
-#   npx convex env set SENDER_NAME      "Ada"
-#   npx convex env set DELIVERY_MODE    "superhuman"    # or "resend"
+#   npx convex env set ADMIN_KEY     "a-long-random-string"
+#   npx convex env set SENDER_NAME   "Ada"
 #
-# Only needed when DELIVERY_MODE is "resend":
+# Delivery mode is picked in the admin dashboard. This is only the starting
+# value for a deployment where nobody has touched the toggle yet.
 #
-#   npx convex env set RESEND_API_KEY   "re_..."
-#   npx convex env set EMAIL_FROM       "Ada <ada@yourdomain.com>"
-#   npx convex env set EMAIL_REPLY_TO   "ada@yourdomain.com"
+#   npx convex env set DELIVERY_MODE "superhuman"    # or "resend"
+#
+# Needed before the dashboard will let you switch to Resend. EMAIL_FROM has to
+# be on a domain you verified with Resend, not a gmail.com address.
+#
+#   npx convex env set RESEND_API_KEY "re_..."
+#   npx convex env set EMAIL_FROM     "Ada <ada@yourdomain.com>"
+#   npx convex env set EMAIL_REPLY_TO "ada@yourdomain.com"
+#
+# Optional. Lets the dashboard mint giveaway links through the Fourthwall API
+# instead of importing a CSV. Create an API user in Fourthwall under Settings,
+# then For Developers, then the OpenAPI tab.
+#
+#   npx convex env set FOURTHWALL_USERNAME "..."
+#   npx convex env set FOURTHWALL_PASSWORD "..."
+#
+# Multi-shop OAuth apps can use a bearer token instead of the pair above.
+#
+#   npx convex env set FOURTHWALL_TOKEN "..."

--- a/swag/.env.example
+++ b/swag/.env.example
@@ -1,0 +1,16 @@
+# Local development only. `npx convex dev` writes these for you.
+# CONVEX_DEPLOYMENT=
+# VITE_CONVEX_URL=
+
+# Everything else lives on the Convex deployment, not in this file.
+# Set those with the CLI:
+#
+#   npx convex env set ADMIN_KEY        "a-long-random-string"
+#   npx convex env set SENDER_NAME      "Ada"
+#   npx convex env set DELIVERY_MODE    "superhuman"    # or "resend"
+#
+# Only needed when DELIVERY_MODE is "resend":
+#
+#   npx convex env set RESEND_API_KEY   "re_..."
+#   npx convex env set EMAIL_FROM       "Ada <ada@yourdomain.com>"
+#   npx convex env set EMAIL_REPLY_TO   "ada@yourdomain.com"

--- a/swag/.gitignore
+++ b/swag/.gitignore
@@ -1,0 +1,18 @@
+node_modules
+dist
+dist-ssr
+*.local
+.env.local
+.env.*.local
+
+# Convex local deployment state
+.convex
+
+# TypeScript build info
+*.tsbuildinfo
+
+# Editor
+.DS_Store
+.vscode/*
+!.vscode/extensions.json
+.idea

--- a/swag/.gitignore
+++ b/swag/.gitignore
@@ -5,6 +5,9 @@ dist-ssr
 .env.local
 .env.*.local
 
+# The root .gitignore excludes all .env* files, so re-include the template
+!.env.example
+
 # Convex local deployment state
 .convex
 

--- a/swag/README.md
+++ b/swag/README.md
@@ -10,16 +10,16 @@ deployment. There is no second host and no DNS to point anywhere.
 ## How it works
 
 ```
-Fourthwall CSV  ->  admin imports links  ->  pool of unclaimed links
-                                                     |
+Fourthwall API or CSV  ->  pool of unclaimed links
+                                    |
 person fills the form  ->  claims.submit  ->  assigns exactly one link
-                                                     |
-                                              outbox row (pending)
-                                                     |
-                          +--------------------------+-------------------------+
-                          |                                                    |
-                 Resend component                                 Superhuman Mail MCP
-                 sends immediately                          your assistant sends it as you
+                                    |
+                             outbox row (pending)
+                                    |
+             +----------------------+----------------------+
+             |                                             |
+      Resend component                          Superhuman Mail MCP
+      sends immediately                    your assistant sends it as you
 ```
 
 The outbox is the single source of truth. Both delivery paths drain the same
@@ -27,34 +27,50 @@ queue and mark the same rows sent, so a link can never go out twice.
 
 ## Choosing how email gets sent
 
-This was the open question, and the answer is that the two options are not
-interchangeable.
+Pick the mode in the admin dashboard under Settings. It is stored in the
+database, so you can switch mid event without a redeploy. Both paths produce
+the same subject and body, so switching does not change what lands in an inbox.
+
+| Mode | Behaviour |
+| --- | --- |
+| Superhuman | Claims queue in the outbox. You drain them from an AI client connected to Superhuman, so mail leaves your own mailbox |
+| Resend | The Convex Resend component sends the instant someone submits |
+
+**The thing that usually decides it: Resend can only send from a domain you
+control.** You verify the domain by adding DNS records, so `EMAIL_FROM` has to
+be something like `you@yourdomain.com`. Resend cannot send as `you@gmail.com`,
+since you cannot add DNS records to Google's domain. Superhuman connects to the
+Gmail or Outlook account itself, so mail comes from your real everyday address.
+
+So, roughly:
+
+- You own a domain and want links delivered in seconds: use Resend. It is less
+  work and nothing waits on you
+- The mail has to come from your personal address: use Superhuman
+- Not sure: start on Superhuman for the first handful, switch to Resend when the
+  volume stops being fun
 
 **Superhuman Mail MCP** is real and it does send email. The server lives at
 `https://mcp.mail.superhuman.com/mcp`, authenticates over OAuth, and exposes a
 `send_draft` tool. What it is not is a server to server API. It authenticates a
 person in an AI client, not a backend holding a key, so a Convex action cannot
 call it when someone submits the form. It needs a Superhuman Mail account on
-the Business or Enterprise plan with Ask AI turned on.
-
-What it gives you that nothing else does: the email genuinely comes from your
-mailbox, lands in the recipient's normal thread with you, and can be written in
-your voice. For a few dozen friends that is the whole point.
-
-**Resend** through the `@convex-dev/resend` component is the opposite trade. It
-sends the instant someone submits, with retries and delivery webhooks, from a
-domain you verified. It reads like a transactional email, since it is one.
-
-Set `DELIVERY_MODE` to pick:
-
-| Mode | Behaviour | Use when |
-| --- | --- | --- |
-| `superhuman` (default) | Claims queue in the outbox. You drain them from an AI client connected to Superhuman. | The personal touch matters more than the wait |
-| `resend` | Sent automatically on submit. | You want people to get their link in seconds |
-
-Either way the recipient sees the same subject and body, so switching modes
-does not change what lands in the inbox. Setting up Superhuman is covered in
+the Business or Enterprise plan with Ask AI turned on. Setup is in
 [SUPERHUMAN.md](./SUPERHUMAN.md).
+
+**Resend** through the `@convex-dev/resend` component sends automatically, with
+retries and delivery webhooks. The dashboard will not let you switch to it
+until `RESEND_API_KEY` and `EMAIL_FROM` are both set, since queuing mail that
+can never send is worse than refusing the switch.
+
+### What the delivery statuses mean
+
+`resend.sendEmail` enqueues into a workpool rather than calling Resend inline,
+so a successful call means "accepted", not "delivered". Rows sit in **sending**
+until their fate is known, then move to **sent** or **failed**. Two things
+resolve them: the delivery webhook, and a scheduled check that asks the Resend
+component directly. The second one exists so the dashboard still tells the
+truth on a deployment with no webhook configured.
 
 ## Setup
 
@@ -75,13 +91,12 @@ Then set the deployment configuration:
 ```bash
 npx convex env set ADMIN_KEY "$(openssl rand -hex 24)"
 npx convex env set SENDER_NAME "Ada"
-npx convex env set DELIVERY_MODE "superhuman"
 ```
 
 `ADMIN_KEY` is the password for `/admin` and for the outbox HTTP API. Print it
 somewhere you can find it, and rotate it after an event.
 
-For `resend` mode, add:
+For Resend mode, add:
 
 ```bash
 npx convex env set RESEND_API_KEY "re_..."
@@ -94,22 +109,42 @@ so bounces show up in the admin dashboard.
 
 ## Loading Fourthwall links
 
+Two ways in. Both land in the same pool and dedupe against each other.
+
+### Generate them through the API
+
+Create an API user in Fourthwall under Settings, then For Developers, then the
+OpenAPI tab. That gives a username and password.
+
+```bash
+npx convex env set FOURTHWALL_USERNAME "..."
+npx convex env set FOURTHWALL_PASSWORD "..."
+```
+
+Open `/admin`, go to Links, load your products, pick one, choose how many links
+you want, and generate. The app calls
+`POST https://api.fourthwall.com/open-api/v1.0/giveaway-links`, gets the links
+back, and adds them to the pool in one step. No spreadsheet.
+
+Multi-shop OAuth apps can set `FOURTHWALL_TOKEN` instead of the username and
+password pair, which sends a bearer token and needs the `giveaway_write` scope.
+
+### Or import a CSV
+
 In Fourthwall, go to Promotions, then Create promotion, then Giveaway links.
 Pick one product, enter how many links you need, save, then click **Export
-links** to get the CSV.
+links**.
 
-Open `/admin`, go to the Links tab, and either upload that CSV or paste the
-column of links from your spreadsheet. The importer scans for URLs rather than
-parsing columns, so the exact CSV layout does not matter. Links are deduped on
-their code, and re-importing the same file imports nothing new.
+Upload that CSV in the Links tab, or paste the column from your spreadsheet.
+The importer scans for URLs rather than parsing columns, so the exact layout
+does not matter.
 
-Giveaway links are single use and charge your card on file for the product and
-shipping when someone redeems one.
+### Either way
 
-Fourthwall also has a `POST /open-api/v1.0/giveaway-links` endpoint behind the
-`giveaway_write` scope if you would rather generate links from code. That is
-not wired up here, since the CSV path needs no API key and matches how the
-dashboard already works.
+Links are deduped on their code, so re-importing a file or regenerating adds
+nothing twice. Giveaway links are single use, and Fourthwall charges your card
+on file for the product and shipping when someone redeems one. Generating links
+through the API is a real action in your shop that costs real money.
 
 ## Deploying
 
@@ -128,11 +163,12 @@ tab and never written to disk.
 
 - **Outbox** shows what is waiting, the prompt to hand your assistant, and
   buttons to mark rows sent or requeue failures
-- **Links** imports giveaway links and shows how many are left
+- **Links** generates links through the Fourthwall API, imports links you
+  already have, and shows how many are left
 - **Claims** lists everyone who signed up with their delivery status, and
   exports a CSV
-- **Settings** closes claims, and controls whether the link is shown on screen
-  as well as emailed
+- **Settings** picks the delivery mode, closes claims, and controls whether the
+  link is shown on screen as well as emailed
 
 ## Notes on correctness
 

--- a/swag/README.md
+++ b/swag/README.md
@@ -1,0 +1,153 @@
+# Friends of Convex
+
+A single page app for handing out free swag. People you invite fill in their
+name, X handle and email. The app hands each person one Fourthwall giveaway
+link from a pool you imported, then emails it to them from you.
+
+Backend, database, HTTP API and the frontend itself all run on one Convex
+deployment. There is no second host and no DNS to point anywhere.
+
+## How it works
+
+```
+Fourthwall CSV  ->  admin imports links  ->  pool of unclaimed links
+                                                     |
+person fills the form  ->  claims.submit  ->  assigns exactly one link
+                                                     |
+                                              outbox row (pending)
+                                                     |
+                          +--------------------------+-------------------------+
+                          |                                                    |
+                 Resend component                                 Superhuman Mail MCP
+                 sends immediately                          your assistant sends it as you
+```
+
+The outbox is the single source of truth. Both delivery paths drain the same
+queue and mark the same rows sent, so a link can never go out twice.
+
+## Choosing how email gets sent
+
+This was the open question, and the answer is that the two options are not
+interchangeable.
+
+**Superhuman Mail MCP** is real and it does send email. The server lives at
+`https://mcp.mail.superhuman.com/mcp`, authenticates over OAuth, and exposes a
+`send_draft` tool. What it is not is a server to server API. It authenticates a
+person in an AI client, not a backend holding a key, so a Convex action cannot
+call it when someone submits the form. It needs a Superhuman Mail account on
+the Business or Enterprise plan with Ask AI turned on.
+
+What it gives you that nothing else does: the email genuinely comes from your
+mailbox, lands in the recipient's normal thread with you, and can be written in
+your voice. For a few dozen friends that is the whole point.
+
+**Resend** through the `@convex-dev/resend` component is the opposite trade. It
+sends the instant someone submits, with retries and delivery webhooks, from a
+domain you verified. It reads like a transactional email, since it is one.
+
+Set `DELIVERY_MODE` to pick:
+
+| Mode | Behaviour | Use when |
+| --- | --- | --- |
+| `superhuman` (default) | Claims queue in the outbox. You drain them from an AI client connected to Superhuman. | The personal touch matters more than the wait |
+| `resend` | Sent automatically on submit. | You want people to get their link in seconds |
+
+Either way the recipient sees the same subject and body, so switching modes
+does not change what lands in the inbox. Setting up Superhuman is covered in
+[SUPERHUMAN.md](./SUPERHUMAN.md).
+
+## Setup
+
+```bash
+cd swag
+npm install
+npx convex dev
+```
+
+That provisions a deployment and writes `.env.local`. In a second terminal:
+
+```bash
+npm run dev:frontend
+```
+
+Then set the deployment configuration:
+
+```bash
+npx convex env set ADMIN_KEY "$(openssl rand -hex 24)"
+npx convex env set SENDER_NAME "Ada"
+npx convex env set DELIVERY_MODE "superhuman"
+```
+
+`ADMIN_KEY` is the password for `/admin` and for the outbox HTTP API. Print it
+somewhere you can find it, and rotate it after an event.
+
+For `resend` mode, add:
+
+```bash
+npx convex env set RESEND_API_KEY "re_..."
+npx convex env set EMAIL_FROM "Ada <ada@yourdomain.com>"
+npx convex env set EMAIL_REPLY_TO "ada@yourdomain.com"
+```
+
+Then point a Resend webhook at `https://<deployment>.convex.site/api/resend-webhook`
+so bounces show up in the admin dashboard.
+
+## Loading Fourthwall links
+
+In Fourthwall, go to Promotions, then Create promotion, then Giveaway links.
+Pick one product, enter how many links you need, save, then click **Export
+links** to get the CSV.
+
+Open `/admin`, go to the Links tab, and either upload that CSV or paste the
+column of links from your spreadsheet. The importer scans for URLs rather than
+parsing columns, so the exact CSV layout does not matter. Links are deduped on
+their code, and re-importing the same file imports nothing new.
+
+Giveaway links are single use and charge your card on file for the product and
+shipping when someone redeems one.
+
+Fourthwall also has a `POST /open-api/v1.0/giveaway-links` endpoint behind the
+`giveaway_write` scope if you would rather generate links from code. That is
+not wired up here, since the CSV path needs no API key and matches how the
+dashboard already works.
+
+## Deploying
+
+```bash
+npm run deploy
+```
+
+That builds the frontend, pushes the Convex functions, and uploads the built
+files to the static hosting component. The site ends up at
+`https://<deployment>.convex.site`, with `/admin` on the same origin.
+
+## Admin dashboard
+
+`/admin`, unlocked with `ADMIN_KEY`, which is held in `sessionStorage` for the
+tab and never written to disk.
+
+- **Outbox** shows what is waiting, the prompt to hand your assistant, and
+  buttons to mark rows sent or requeue failures
+- **Links** imports giveaway links and shows how many are left
+- **Claims** lists everyone who signed up with their delivery status, and
+  exports a CSV
+- **Settings** closes claims, and controls whether the link is shown on screen
+  as well as emailed
+
+## Notes on correctness
+
+Link assignment happens inside one Convex mutation, and mutations are
+serializable transactions. Two people submitting at the same instant cannot be
+handed the same link: the second transaction conflicts and retries against the
+updated status.
+
+Someone submitting twice gets their original link back rather than burning a
+second one. Duplicates are caught on email and on X handle, both normalized
+first, so `@Ada`, `ada` and `https://x.com/ada` are one person.
+
+Marking an outbox row sent is idempotent. Replaying the same ids reports them
+as skipped instead of resending.
+
+Admin access is a shared secret rather than a user session. The claim form is
+deliberately anonymous, so there is no identity to check against. Treat
+`ADMIN_KEY` like a password.

--- a/swag/SUPERHUMAN.md
+++ b/swag/SUPERHUMAN.md
@@ -1,0 +1,135 @@
+# Sending swag emails through Superhuman
+
+The Superhuman Mail MCP server lets an AI client send email from your actual
+mailbox. This is how you use it to drain the swag outbox, so every link arrives
+as a normal message from you rather than a transactional blast.
+
+## What you need
+
+- A Superhuman Mail account on the Business or Enterprise plan with Ask AI
+  turned on
+- An MCP client that supports remote HTTP servers, such as Cursor, Claude or
+  ChatGPT
+- Your deployment's `ADMIN_KEY`
+
+## Why the backend cannot do this for you
+
+The Superhuman MCP server authenticates a person through OAuth inside an AI
+client. There is no API key a Convex action could hold, so nothing on the
+server can call `send_draft` on its own. The app works around that by exposing
+the queue over HTTP and letting your assistant be the sender.
+
+That is the trade. Mail comes from you, and in exchange sending is something
+you kick off rather than something that happens on submit.
+
+## Connect the MCP server
+
+Add the remote server to your client. In Cursor, `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "superhuman-mail": {
+      "url": "https://mcp.mail.superhuman.com/mcp"
+    }
+  }
+}
+```
+
+Approve the OAuth prompt on first use. Keep the confirm-before-send option on
+until you trust the flow.
+
+## The outbox API
+
+Both endpoints authenticate with `Authorization: Bearer <ADMIN_KEY>`.
+
+**Read what is waiting**
+
+```bash
+curl -H "Authorization: Bearer $SWAG_ADMIN_KEY" \
+  "https://<deployment>.convex.site/api/outbox/pending?limit=25"
+```
+
+```json
+{
+  "count": 1,
+  "emails": [
+    {
+      "id": "jh7etspdvm3xqt8c1ztwrcxpkd8bt5ra",
+      "to": "ada@example.com",
+      "toName": "Ada Lovelace",
+      "twitterHandle": "adalovelace",
+      "subject": "Ada, your Convex swag is ready",
+      "html": "<!doctype html>...",
+      "text": "Friends of Convex...",
+      "linkUrl": "https://yourshop.fourthwall.com/gift/abc123",
+      "createdAt": 1785883261862
+    }
+  ]
+}
+```
+
+**Mark them sent**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $SWAG_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"ids":["jh7etspdvm3xqt8c1ztwrcxpkd8bt5ra"]}' \
+  "https://<deployment>.convex.site/api/outbox/sent"
+```
+
+```json
+{ "marked": 1, "skipped": 0 }
+```
+
+Ids already marked sent come back under `skipped`, so replaying a request never
+mails anyone twice.
+
+## The prompt
+
+The Outbox tab in `/admin` shows this with your real URL filled in and a copy
+button.
+
+```
+Send the pending Convex swag emails from my Superhuman account.
+
+1. GET https://<deployment>.convex.site/api/outbox/pending with header
+   "Authorization: Bearer $SWAG_ADMIN_KEY".
+2. For each email in the response, call the Superhuman send_draft tool with:
+   To: the "to" field
+   Subject: the "subject" field
+   HTML body: the "html" field, exactly as given, do not rewrite it
+3. Straight after each successful send, POST the id back so it is not sent twice:
+   POST https://<deployment>.convex.site/api/outbox/sent
+   Header: Authorization: Bearer $SWAG_ADMIN_KEY
+   Body: {"ids": ["<the id>"]}
+
+Each link is single use. Never send the same id twice, and stop and tell me if
+a send fails.
+```
+
+## Rules worth keeping
+
+**Send the HTML as given.** Superhuman will happily rewrite a message in your
+voice. Let it do that for replies, not for this. The body carries a single use
+link, and a rewrite can drop or mangle it.
+
+**Mark each id sent immediately after its send returns**, not in one batch at
+the end. If the run dies halfway, the rows that already went out are recorded
+and the rest stay queued.
+
+**One id, one person, one link.** If a send fails, leave the row pending or
+requeue it from the dashboard. Do not retry by re-reading and re-sending the
+whole list without marking as you go.
+
+## If something goes wrong
+
+A send that fails on your end leaves the row pending, so the next run picks it
+up. Nothing is lost.
+
+If you sent an email outside this flow, open the Outbox tab and hit **Mark
+sent** on that row so it stops reappearing.
+
+To put a row back in the queue, use **Requeue** on the failed list in the
+dashboard, or call `outbox:markPending` with the id.

--- a/swag/changelog.md
+++ b/swag/changelog.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.2.0
+
+### Added
+
+- **Generate links through the Fourthwall API.** The Links tab can load your
+  products and mint giveaway links straight into the pool, so the CSV export
+  and import round trip is optional now. Set `FOURTHWALL_USERNAME` and
+  `FOURTHWALL_PASSWORD`, or `FOURTHWALL_TOKEN` for OAuth apps
+- **Delivery mode picker in the dashboard.** Superhuman and Resend are now
+  chosen under Settings rather than through an environment variable, so the
+  mode can change mid event. `DELIVERY_MODE` is still read as the starting
+  value for a fresh deployment
+- **Guard against switching to Resend before it works.** The dashboard refuses
+  the switch until `RESEND_API_KEY` and `EMAIL_FROM` are set, rather than
+  queueing mail that can never send
+- **Resend status diagnostics.** An admin query reports what the Resend
+  component knows about an email, so a row stuck in sending can be explained
+
+### Fixed
+
+- **Resend rows reported "sent" when nothing had been sent.** `sendEmail`
+  enqueues into a workpool rather than calling Resend inline, so a successful
+  call only means accepted. Rows now stay in sending until the webhook or a
+  scheduled reconciliation resolves them to sent or failed. An invalid API key
+  used to look like a clean send and now surfaces the real error
+- **Reconciliation missed terminal failures.** The Resend component reports
+  some failures through `status.status` without setting the matching boolean
+  flag, so failed emails were rescheduled instead of being marked failed
+
 ## 0.1.0
 
 First version. A swag giveaway app that runs entirely on one Convex

--- a/swag/changelog.md
+++ b/swag/changelog.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## 0.1.0
+
+First version. A swag giveaway app that runs entirely on one Convex
+deployment.
+
+### Added
+
+- **Claim form** at `/` collecting name, X handle and email, with the
+  confirmation screen showing the assigned link
+- **Single link per person.** Assignment happens inside one Convex mutation, so
+  simultaneous submissions cannot collide on the same link
+- **Duplicate handling** on both email and X handle, normalized first, so a
+  repeat submission returns the original link instead of burning another
+- **Fourthwall link import** from the CSV export or pasted spreadsheet columns,
+  deduped on link code so re-importing a file is safe
+- **Outbox queue** as the single source of truth for delivery, with idempotent
+  mark sent
+- **Two delivery paths off that one queue.** Resend sends automatically on
+  submit. Superhuman Mail MCP lets your assistant send from your own mailbox
+- **Outbox HTTP API** at `/api/outbox/pending` and `/api/outbox/sent` so an
+  MCP-connected assistant can read the queue and record what it sent
+- **Admin dashboard** at `/admin` with outbox, links, claims and settings tabs
+- **Runtime settings** for closing claims and for hiding the link so email is
+  the only way to receive it
+- **Resend delivery webhook** that marks bounced and complained mail failed and
+  surfaces it for a retry
+- **Convex static hosting** serving the built SPA from the same deployment,
+  with the `/api` routes taking precedence over the SPA catch-all

--- a/swag/convex/_generated/api.d.ts
+++ b/swag/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as claims from "../claims.js";
 import type * as emails from "../emails.js";
+import type * as fourthwall from "../fourthwall.js";
 import type * as http from "../http.js";
 import type * as lib_admin from "../lib/admin.js";
 import type * as lib_emailTemplate from "../lib/emailTemplate.js";
@@ -28,6 +29,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   claims: typeof claims;
   emails: typeof emails;
+  fourthwall: typeof fourthwall;
   http: typeof http;
   "lib/admin": typeof lib_admin;
   "lib/emailTemplate": typeof lib_emailTemplate;

--- a/swag/convex/_generated/api.d.ts
+++ b/swag/convex/_generated/api.d.ts
@@ -1,0 +1,70 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as claims from "../claims.js";
+import type * as emails from "../emails.js";
+import type * as http from "../http.js";
+import type * as lib_admin from "../lib/admin.js";
+import type * as lib_emailTemplate from "../lib/emailTemplate.js";
+import type * as lib_env from "../lib/env.js";
+import type * as lib_validation from "../lib/validation.js";
+import type * as links from "../links.js";
+import type * as outbox from "../outbox.js";
+import type * as settings from "../settings.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  claims: typeof claims;
+  emails: typeof emails;
+  http: typeof http;
+  "lib/admin": typeof lib_admin;
+  "lib/emailTemplate": typeof lib_emailTemplate;
+  "lib/env": typeof lib_env;
+  "lib/validation": typeof lib_validation;
+  links: typeof links;
+  outbox: typeof outbox;
+  settings: typeof settings;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  staticHosting: import("@convex-dev/static-hosting/_generated/component.js").ComponentApi<"staticHosting">;
+  resend: import("@convex-dev/resend/_generated/component.js").ComponentApi<"resend">;
+};

--- a/swag/convex/_generated/api.js
+++ b/swag/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/swag/convex/_generated/dataModel.d.ts
+++ b/swag/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/swag/convex/_generated/server.d.ts
+++ b/swag/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/swag/convex/_generated/server.js
+++ b/swag/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/swag/convex/claims.ts
+++ b/swag/convex/claims.ts
@@ -6,8 +6,8 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { requireAdmin } from "./lib/admin";
 import { validateClaimInput } from "./lib/validation";
 import { renderSwagEmail } from "./lib/emailTemplate";
-import { getBooleanSetting } from "./settings";
-import { deliveryMode, senderName } from "./lib/env";
+import { getBooleanSetting, getDeliveryMode } from "./settings";
+import { senderName } from "./lib/env";
 
 const vSubmitResult = v.union(
   v.object({
@@ -130,8 +130,7 @@ export const submit = mutation({
 
     // In superhuman mode the row is left pending for you to drain, so the mail
     // goes out from your own mailbox instead of a transactional sender.
-    const autoSend = deliveryMode() === "resend";
-    if (autoSend) {
+    if ((await getDeliveryMode(ctx)) === "resend") {
       await ctx.scheduler.runAfter(0, internal.emails.deliverViaResend, {
         outboxId,
       });

--- a/swag/convex/claims.ts
+++ b/swag/convex/claims.ts
@@ -1,0 +1,195 @@
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { mutation, query } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { requireAdmin } from "./lib/admin";
+import { validateClaimInput } from "./lib/validation";
+import { renderSwagEmail } from "./lib/emailTemplate";
+import { getBooleanSetting } from "./settings";
+import { deliveryMode, senderName } from "./lib/env";
+
+const vSubmitResult = v.union(
+  v.object({
+    status: v.literal("claimed"),
+    linkUrl: v.union(v.string(), v.null()),
+    emailQueued: v.boolean(),
+  }),
+  v.object({
+    status: v.literal("already_claimed"),
+    linkUrl: v.union(v.string(), v.null()),
+  }),
+  v.object({ status: v.literal("closed") }),
+  v.object({ status: v.literal("out_of_links") })
+);
+
+/** Finds the existing claim for this person, by email or by X handle. */
+async function findExistingClaim(
+  ctx: MutationCtx,
+  email: string,
+  twitterHandle: string
+): Promise<Doc<"claims"> | null> {
+  const byEmail = await ctx.db
+    .query("claims")
+    .withIndex("by_email", (q) => q.eq("email", email))
+    .first();
+  if (byEmail) return byEmail;
+
+  return await ctx.db
+    .query("claims")
+    .withIndex("by_twitterHandle", (q) => q.eq("twitterHandle", twitterHandle))
+    .first();
+}
+
+/**
+ * Assigns one giveaway link and queues the email.
+ *
+ * Convex mutations are serializable transactions, so two people submitting at
+ * the same instant cannot be handed the same link: the second transaction
+ * conflicts and retries against the updated link status.
+ */
+export const submit = mutation({
+  args: {
+    name: v.string(),
+    email: v.string(),
+    twitterHandle: v.string(),
+  },
+  returns: vSubmitResult,
+  handler: async (ctx, args) => {
+    if (!(await getBooleanSetting(ctx, "claimsOpen"))) {
+      return { status: "closed" as const };
+    }
+
+    const input = validateClaimInput(args);
+    const reveal = await getBooleanSetting(ctx, "revealLinkOnClaim");
+
+    // Re-submitting returns the original link rather than burning a second one.
+    const existing = await findExistingClaim(
+      ctx,
+      input.email,
+      input.twitterHandle
+    );
+    if (existing) {
+      return {
+        status: "already_claimed" as const,
+        linkUrl: reveal ? existing.linkUrl : null,
+      };
+    }
+
+    const link = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_status", (q) => q.eq("status", "available"))
+      .first();
+    if (!link) {
+      return { status: "out_of_links" as const };
+    }
+
+    const now = Date.now();
+    const claimId: Id<"claims"> = await ctx.db.insert("claims", {
+      name: input.name,
+      twitterHandle: input.twitterHandle,
+      twitterHandleRaw: input.twitterHandleRaw,
+      email: input.email,
+      linkId: link._id,
+      linkUrl: link.url,
+      createdAt: now,
+    });
+
+    await ctx.db.patch(link._id, {
+      status: "assigned",
+      assignedClaimId: claimId,
+      assignedAt: now,
+    });
+
+    const rendered = renderSwagEmail({
+      recipientName: input.name,
+      linkUrl: link.url,
+      senderName: senderName(),
+    });
+
+    const outboxId = await ctx.db.insert("outbox", {
+      claimId,
+      to: input.email,
+      toName: input.name,
+      twitterHandle: input.twitterHandle,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      linkUrl: link.url,
+      status: "pending",
+      createdAt: now,
+    });
+
+    // In superhuman mode the row is left pending for you to drain, so the mail
+    // goes out from your own mailbox instead of a transactional sender.
+    const autoSend = deliveryMode() === "resend";
+    if (autoSend) {
+      await ctx.scheduler.runAfter(0, internal.emails.deliverViaResend, {
+        outboxId,
+      });
+    }
+
+    return {
+      status: "claimed" as const,
+      linkUrl: reveal ? link.url : null,
+      emailQueued: true,
+    };
+  },
+});
+
+const vAdminClaim = v.object({
+  _id: v.id("claims"),
+  _creationTime: v.number(),
+  name: v.string(),
+  email: v.string(),
+  twitterHandle: v.string(),
+  twitterHandleRaw: v.string(),
+  linkUrl: v.string(),
+  createdAt: v.number(),
+  emailStatus: v.union(
+    v.literal("pending"),
+    v.literal("sending"),
+    v.literal("sent"),
+    v.literal("failed"),
+    v.literal("unknown")
+  ),
+});
+
+/** Most recent claims with their delivery status, for the admin table. */
+export const listRecent = query({
+  args: {
+    key: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(vAdminClaim),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    const limit = Math.min(args.limit ?? 50, 200);
+
+    const claims = await ctx.db
+      .query("claims")
+      .withIndex("by_createdAt")
+      .order("desc")
+      .take(limit);
+
+    const rows = [];
+    for (const claim of claims) {
+      const outboxRow = await ctx.db
+        .query("outbox")
+        .withIndex("by_claimId", (q) => q.eq("claimId", claim._id))
+        .first();
+      rows.push({
+        _id: claim._id,
+        _creationTime: claim._creationTime,
+        name: claim.name,
+        email: claim.email,
+        twitterHandle: claim.twitterHandle,
+        twitterHandleRaw: claim.twitterHandleRaw,
+        linkUrl: claim.linkUrl,
+        createdAt: claim.createdAt,
+        emailStatus: outboxRow?.status ?? ("unknown" as const),
+      });
+    }
+    return rows;
+  },
+});

--- a/swag/convex/claims.ts
+++ b/swag/convex/claims.ts
@@ -20,7 +20,8 @@ const vSubmitResult = v.union(
     linkUrl: v.union(v.string(), v.null()),
   }),
   v.object({ status: v.literal("closed") }),
-  v.object({ status: v.literal("out_of_links") })
+  v.object({ status: v.literal("out_of_links") }),
+  v.object({ status: v.literal("invalid"), message: v.string() })
 );
 
 /** Finds the existing claim for this person, by email or by X handle. */
@@ -60,7 +61,14 @@ export const submit = mutation({
       return { status: "closed" as const };
     }
 
-    const input = validateClaimInput(args);
+    // A typo is an expected outcome, not an exception, so it comes back as a
+    // result the form can render instead of a thrown server error.
+    const validation = validateClaimInput(args);
+    if (!validation.ok) {
+      return { status: "invalid" as const, message: validation.message };
+    }
+    const input = validation.value;
+
     const reveal = await getBooleanSetting(ctx, "revealLinkOnClaim");
 
     // Re-submitting returns the original link rather than burning a second one.

--- a/swag/convex/convex.config.ts
+++ b/swag/convex/convex.config.ts
@@ -1,0 +1,11 @@
+import { defineApp } from "convex/server";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
+import resend from "@convex-dev/resend/convex.config";
+
+// The app owns HTTP routing so the outbox API can keep stable /api/* URLs.
+// registerStaticRoutes in convex/http.ts serves the SPA from everything else.
+const app = defineApp();
+app.use(staticHosting);
+app.use(resend);
+
+export default app;

--- a/swag/convex/emails.ts
+++ b/swag/convex/emails.ts
@@ -1,0 +1,105 @@
+import { v } from "convex/values";
+import { Resend, vOnEmailEventArgs } from "@convex-dev/resend";
+import { components, internal } from "./_generated/api";
+import { internalMutation, mutation } from "./_generated/server";
+import { requireAdmin } from "./lib/admin";
+import { fromAddress, replyToAddresses } from "./lib/env";
+
+/**
+ * testMode is off because the whole point is mailing real people. Resend will
+ * refuse to send until RESEND_API_KEY is set on the deployment.
+ */
+export const resend: Resend = new Resend(components.resend, {
+  testMode: false,
+  onEmailEvent: internal.emails.handleEmailEvent,
+});
+
+/** Sends one queued outbox row through Resend. */
+export const deliverViaResend = internalMutation({
+  args: { outboxId: v.id("outbox") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.outboxId);
+    if (!row) {
+      throw new Error("Outbox row not found");
+    }
+    // Guards against a retry double-sending the same link.
+    if (row.status === "sent" || row.status === "sending") {
+      return null;
+    }
+
+    await ctx.db.patch(args.outboxId, { status: "sending" });
+
+    try {
+      const emailId = await resend.sendEmail(ctx, {
+        from: fromAddress(),
+        to: row.to,
+        subject: row.subject,
+        html: row.html,
+        text: row.text,
+        replyTo: replyToAddresses(),
+      });
+
+      await ctx.db.patch(args.outboxId, {
+        status: "sent",
+        channel: "resend",
+        resendEmailId: emailId,
+        sentAt: Date.now(),
+        error: undefined,
+      });
+    } catch (error) {
+      await ctx.db.patch(args.outboxId, {
+        status: "failed",
+        error: error instanceof Error ? error.message : "Unknown send error",
+      });
+      throw error;
+    }
+    return null;
+  },
+});
+
+/**
+ * Resend delivery webhook. Bounces and complaints flip the row back to failed
+ * so it shows up in the admin table and can be retried or sent by hand.
+ */
+export const handleEmailEvent = internalMutation({
+  args: vOnEmailEventArgs,
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("outbox")
+      .withIndex("by_resendEmailId", (q) => q.eq("resendEmailId", args.id))
+      .first();
+    if (!row) return null;
+
+    const failureEvents = ["email.bounced", "email.complained", "email.failed"];
+    if (failureEvents.includes(args.event.type)) {
+      await ctx.db.patch(row._id, {
+        status: "failed",
+        error: args.event.type,
+      });
+    }
+    return null;
+  },
+});
+
+/** Retries a failed row through Resend from the admin dashboard. */
+export const retry = mutation({
+  args: {
+    key: v.string(),
+    outboxId: v.id("outbox"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    const row = await ctx.db.get(args.outboxId);
+    if (!row) {
+      throw new Error("Outbox row not found");
+    }
+    await ctx.db.patch(args.outboxId, { status: "pending", error: undefined });
+    await ctx.scheduler.runAfter(0, internal.emails.deliverViaResend, {
+      outboxId: args.outboxId,
+    });
+    return null;
+  },
+});

--- a/swag/convex/emails.ts
+++ b/swag/convex/emails.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
-import { Resend, vOnEmailEventArgs } from "@convex-dev/resend";
+import { Resend, vOnEmailEventArgs, type EmailId } from "@convex-dev/resend";
 import { components, internal } from "./_generated/api";
-import { internalMutation, mutation } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { requireAdmin } from "./lib/admin";
 import { fromAddress, replyToAddresses } from "./lib/env";
 
@@ -14,7 +14,17 @@ export const resend: Resend = new Resend(components.resend, {
   onEmailEvent: internal.emails.handleEmailEvent,
 });
 
-/** Sends one queued outbox row through Resend. */
+/** How long to wait between checks on an email Resend has not resolved yet. */
+const RECONCILE_DELAY_MS = 60_000;
+const MAX_RECONCILE_ATTEMPTS = 6;
+
+/**
+ * Hands one queued outbox row to Resend.
+ *
+ * `sendEmail` only enqueues into the component's workpool, so a successful
+ * call means "accepted for sending", not "delivered". The row stays in
+ * "sending" until either the webhook or reconcileResend learns its fate.
+ */
 export const deliverViaResend = internalMutation({
   args: { outboxId: v.id("outbox") },
   returns: v.null(),
@@ -41,12 +51,16 @@ export const deliverViaResend = internalMutation({
       });
 
       await ctx.db.patch(args.outboxId, {
-        status: "sent",
         channel: "resend",
         resendEmailId: emailId,
-        sentAt: Date.now(),
         error: undefined,
       });
+
+      await ctx.scheduler.runAfter(
+        RECONCILE_DELAY_MS,
+        internal.emails.reconcileResend,
+        { outboxId: args.outboxId, attempt: 1 }
+      );
     } catch (error) {
       await ctx.db.patch(args.outboxId, {
         status: "failed",
@@ -59,8 +73,77 @@ export const deliverViaResend = internalMutation({
 });
 
 /**
- * Resend delivery webhook. Bounces and complaints flip the row back to failed
- * so it shows up in the admin table and can be retried or sent by hand.
+ * Asks the Resend component what happened to an email.
+ *
+ * The webhook is faster, and this exists so the dashboard still tells the
+ * truth on a deployment where no webhook is configured.
+ */
+export const reconcileResend = internalMutation({
+  args: {
+    outboxId: v.id("outbox"),
+    attempt: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.outboxId);
+    if (!row || row.status !== "sending" || !row.resendEmailId) {
+      return null;
+    }
+
+    const status = await resend.status(ctx, row.resendEmailId as EmailId);
+    if (!status) return null;
+
+    if (status.status === "delivered") {
+      await ctx.db.patch(args.outboxId, {
+        status: "sent",
+        sentAt: Date.now(),
+        error: undefined,
+      });
+      return null;
+    }
+
+    // The component reports a terminal failure through `status.status` and
+    // does not always set the matching boolean, so check both.
+    const terminalFailure =
+      status.failed ||
+      status.bounced ||
+      status.status === "failed" ||
+      status.status === "bounced" ||
+      status.status === "cancelled";
+
+    if (terminalFailure) {
+      await ctx.db.patch(args.outboxId, {
+        status: "failed",
+        error: status.errorMessage ?? status.status,
+      });
+      return null;
+    }
+
+    // "sent" means Resend accepted it but delivery is unconfirmed. Give it a
+    // few more checks, then leave it alone rather than guessing.
+    if (args.attempt >= MAX_RECONCILE_ATTEMPTS) {
+      if (status.status === "sent") {
+        await ctx.db.patch(args.outboxId, {
+          status: "sent",
+          sentAt: Date.now(),
+        });
+      }
+      return null;
+    }
+
+    await ctx.scheduler.runAfter(
+      RECONCILE_DELAY_MS,
+      internal.emails.reconcileResend,
+      { outboxId: args.outboxId, attempt: args.attempt + 1 }
+    );
+    return null;
+  },
+});
+
+/**
+ * Resend delivery webhook, the fast path for learning an email's fate.
+ * Bounces and complaints land in the failed list so they can be retried or
+ * sent by hand.
  */
 export const handleEmailEvent = internalMutation({
   args: vOnEmailEventArgs,
@@ -78,8 +161,55 @@ export const handleEmailEvent = internalMutation({
         status: "failed",
         error: args.event.type,
       });
+      return null;
+    }
+
+    if (args.event.type === "email.delivered") {
+      await ctx.db.patch(row._id, {
+        status: "sent",
+        sentAt: Date.now(),
+        error: undefined,
+      });
     }
     return null;
+  },
+});
+
+/**
+ * What Resend currently thinks of one email. Surfaced in the dashboard so a
+ * row stuck in "sending" can be explained rather than guessed at.
+ */
+export const resendStatus = query({
+  args: {
+    key: v.string(),
+    outboxId: v.id("outbox"),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      status: v.string(),
+      errorMessage: v.union(v.string(), v.null()),
+      bounced: v.boolean(),
+      complained: v.boolean(),
+      failed: v.boolean(),
+    })
+  ),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const row = await ctx.db.get(args.outboxId);
+    if (!row?.resendEmailId) return null;
+
+    const status = await resend.status(ctx, row.resendEmailId as EmailId);
+    if (!status) return null;
+
+    return {
+      status: status.status,
+      errorMessage: status.errorMessage,
+      bounced: status.bounced,
+      complained: status.complained,
+      failed: status.failed,
+    };
   },
 });
 

--- a/swag/convex/fourthwall.ts
+++ b/swag/convex/fourthwall.ts
@@ -1,0 +1,199 @@
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { requireAdmin } from "./lib/admin";
+import { fourthwallAuth, type FourthwallAuth } from "./lib/env";
+
+/**
+ * Fourthwall Platform API, used to mint giveaway links straight into the pool
+ * instead of exporting a CSV and importing it by hand.
+ *
+ * Docs: https://docs.fourthwall.com/api-reference/platform/giveaway-links
+ * Credentials come from Settings, then For Developers, then the OpenAPI tab.
+ */
+const API_BASE = "https://api.fourthwall.com";
+
+/** Fourthwall caps this endpoint at 100 requests per 10 seconds per shop. */
+const MAX_LINKS_PER_CALL = 250;
+
+function authHeader(auth: FourthwallAuth): string {
+  if (auth.kind === "bearer") {
+    return `Bearer ${auth.token}`;
+  }
+  return `Basic ${btoa(`${auth.username}:${auth.password}`)}`;
+}
+
+function requireFourthwall(): FourthwallAuth {
+  const auth = fourthwallAuth();
+  if (!auth) {
+    throw new Error(
+      "Fourthwall is not connected. Set FOURTHWALL_USERNAME and FOURTHWALL_PASSWORD on this deployment."
+    );
+  }
+  return auth;
+}
+
+async function callFourthwall(
+  auth: FourthwallAuth,
+  path: string,
+  init?: RequestInit
+): Promise<unknown> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: authHeader(auth),
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        "Fourthwall rejected the credentials. Check FOURTHWALL_USERNAME and FOURTHWALL_PASSWORD."
+      );
+    }
+    if (response.status === 429) {
+      throw new Error("Fourthwall rate limited the request. Try again shortly.");
+    }
+    throw new Error(
+      `Fourthwall returned ${response.status}: ${body.slice(0, 200)}`
+    );
+  }
+
+  return await response.json();
+}
+
+const vProduct = v.object({
+  id: v.string(),
+  name: v.string(),
+  imageUrl: v.union(v.string(), v.null()),
+});
+
+type ProductResponse = {
+  results?: Array<{
+    id?: unknown;
+    name?: unknown;
+    thumbnailImage?: { url?: unknown };
+    images?: Array<{ url?: unknown }>;
+  }>;
+};
+
+/** Products you can give away, for the picker in the admin dashboard. */
+export const listProducts = action({
+  args: {
+    key: v.string(),
+    search: v.optional(v.string()),
+  },
+  returns: v.array(vProduct),
+  handler: async (_ctx, args) => {
+    requireAdmin(args.key);
+    const auth = requireFourthwall();
+
+    const params = new URLSearchParams({ page: "0", size: "100" });
+    if (args.search) {
+      params.set("search", args.search);
+    }
+
+    const body = (await callFourthwall(
+      auth,
+      `/open-api/v1.0/products?${params.toString()}`
+    )) as ProductResponse;
+
+    const products = [];
+    for (const result of body.results ?? []) {
+      if (typeof result.id !== "string" || typeof result.name !== "string") {
+        continue;
+      }
+      const thumbnail = result.thumbnailImage?.url ?? result.images?.[0]?.url;
+      products.push({
+        id: result.id,
+        name: result.name,
+        imageUrl: typeof thumbnail === "string" ? thumbnail : null,
+      });
+    }
+    return products;
+  },
+});
+
+type GiveawayLinksResponse = {
+  packageId?: unknown;
+  giveawayLinks?: Array<{ link?: unknown; status?: unknown }>;
+};
+
+type GenerateLinksResult = {
+  packageId: string | null;
+  generated: number;
+  imported: number;
+  duplicates: number;
+};
+
+/**
+ * Creates giveaway links on Fourthwall and adds them to the pool in one step.
+ *
+ * Fourthwall charges your card on file for the product and shipping when
+ * someone redeems a link, so this really does spend money.
+ */
+export const generateLinks = action({
+  args: {
+    key: v.string(),
+    productId: v.string(),
+    number: v.number(),
+    batch: v.string(),
+  },
+  returns: v.object({
+    packageId: v.union(v.string(), v.null()),
+    generated: v.number(),
+    imported: v.number(),
+    duplicates: v.number(),
+  }),
+  // Annotated to break the circularity TypeScript sees through the generated
+  // api types when an action calls back into a mutation.
+  handler: async (ctx, args): Promise<GenerateLinksResult> => {
+    requireAdmin(args.key);
+    const auth = requireFourthwall();
+
+    if (!Number.isInteger(args.number) || args.number < 1) {
+      throw new Error("Number of links must be a whole number of at least 1");
+    }
+    if (args.number > MAX_LINKS_PER_CALL) {
+      throw new Error(
+        `Generate at most ${MAX_LINKS_PER_CALL} links at a time, got ${args.number}`
+      );
+    }
+
+    const body = (await callFourthwall(auth, "/open-api/v1.0/giveaway-links", {
+      method: "POST",
+      body: JSON.stringify({
+        productId: args.productId,
+        number: args.number,
+      }),
+    })) as GiveawayLinksResponse;
+
+    // Only unredeemed links are worth adding to the pool.
+    const urls: Array<string> = [];
+    for (const link of body.giveawayLinks ?? []) {
+      if (typeof link.link !== "string") continue;
+      if (link.status !== undefined && link.status !== "AVAILABLE") continue;
+      urls.push(link.link);
+    }
+
+    if (urls.length === 0) {
+      throw new Error("Fourthwall created the package but returned no links");
+    }
+
+    const result: { imported: number; duplicates: number } =
+      await ctx.runMutation(internal.links.addGenerated, {
+        urls,
+        batch: args.batch.trim() || "fourthwall",
+      });
+
+    return {
+      packageId: typeof body.packageId === "string" ? body.packageId : null,
+      generated: urls.length,
+      imported: result.imported,
+      duplicates: result.duplicates,
+    };
+  },
+});

--- a/swag/convex/http.ts
+++ b/swag/convex/http.ts
@@ -22,6 +22,23 @@ function bearerKey(request: Request): string | null {
 }
 
 /**
+ * Convex wraps thrown errors with a stack trace. Surface only the message so
+ * an unauthenticated caller learns nothing about the backend.
+ */
+function unauthorized(error: unknown): Response {
+  const message = error instanceof Error ? error.message : "";
+  const isMisconfigured = message.includes("ADMIN_KEY is not set");
+  return json(
+    {
+      error: isMisconfigured
+        ? "ADMIN_KEY is not set on this deployment"
+        : "Invalid admin key",
+    },
+    401
+  );
+}
+
+/**
  * Outbox API for the Superhuman Mail MCP workflow.
  *
  * The Superhuman MCP server runs inside your AI client, not inside Convex, so
@@ -51,10 +68,7 @@ http.route({
       });
       return json({ count: emails.length, emails });
     } catch (error) {
-      return json(
-        { error: error instanceof Error ? error.message : "Unauthorized" },
-        401
-      );
+      return unauthorized(error);
     }
   }),
 });
@@ -88,10 +102,7 @@ http.route({
       });
       return json(result);
     } catch (error) {
-      return json(
-        { error: error instanceof Error ? error.message : "Unauthorized" },
-        401
-      );
+      return unauthorized(error);
     }
   }),
 });

--- a/swag/convex/http.ts
+++ b/swag/convex/http.ts
@@ -1,0 +1,111 @@
+import { httpRouter } from "convex/server";
+import { registerStaticRoutes } from "@convex-dev/static-hosting";
+import { components, api } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+import { resend } from "./emails";
+import type { Id } from "./_generated/dataModel";
+
+const http = httpRouter();
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Reads the admin key from `Authorization: Bearer <key>`. */
+function bearerKey(request: Request): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice("Bearer ".length).trim() || null;
+}
+
+/**
+ * Outbox API for the Superhuman Mail MCP workflow.
+ *
+ * The Superhuman MCP server runs inside your AI client, not inside Convex, so
+ * the assistant reads pending mail over HTTP, sends it with the send_draft
+ * tool, then posts the ids back here. See SUPERHUMAN.md for the runbook.
+ */
+http.route({
+  path: "/api/outbox/pending",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const key = bearerKey(request);
+    if (!key) {
+      return json({ error: "Missing Authorization: Bearer <ADMIN_KEY>" }, 401);
+    }
+
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get("limit");
+    const limit = limitParam ? Number(limitParam) : undefined;
+    if (limit !== undefined && !Number.isFinite(limit)) {
+      return json({ error: "limit must be a number" }, 400);
+    }
+
+    try {
+      const emails = await ctx.runQuery(api.outbox.listPending, {
+        key,
+        limit,
+      });
+      return json({ count: emails.length, emails });
+    } catch (error) {
+      return json(
+        { error: error instanceof Error ? error.message : "Unauthorized" },
+        401
+      );
+    }
+  }),
+});
+
+http.route({
+  path: "/api/outbox/sent",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const key = bearerKey(request);
+    if (!key) {
+      return json({ error: "Missing Authorization: Bearer <ADMIN_KEY>" }, 401);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "Body must be JSON" }, 400);
+    }
+
+    const ids = (body as { ids?: unknown })?.ids;
+    if (!Array.isArray(ids) || ids.some((id) => typeof id !== "string")) {
+      return json({ error: "Body must be { ids: string[] }" }, 400);
+    }
+
+    try {
+      const result = await ctx.runMutation(api.outbox.markSent, {
+        key,
+        ids: ids as Array<Id<"outbox">>,
+        channel: "superhuman",
+      });
+      return json(result);
+    } catch (error) {
+      return json(
+        { error: error instanceof Error ? error.message : "Unauthorized" },
+        401
+      );
+    }
+  }),
+});
+
+/** Delivery events from Resend, only used when DELIVERY_MODE is "resend". */
+http.route({
+  path: "/api/resend-webhook",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    return await resend.handleResendEventWebhook(ctx, request);
+  }),
+});
+
+// Catch-all. Exact routes above win, everything else serves the SPA.
+registerStaticRoutes(http, components.staticHosting);
+
+export default http;

--- a/swag/convex/lib/admin.ts
+++ b/swag/convex/lib/admin.ts
@@ -1,0 +1,32 @@
+/**
+ * Admin access for this app is a shared secret, not a user session.
+ *
+ * The claim form is deliberately anonymous, so there is no auth provider to
+ * hang `ctx.auth.getUserIdentity()` off of. Admin functions instead require the
+ * ADMIN_KEY environment variable set on the Convex deployment. Anyone holding
+ * that key is an admin, so treat it like a password and rotate it after an
+ * event.
+ */
+
+/** Compares without leaking the position of the first mismatch via timing. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** Throws unless `key` matches the deployment's ADMIN_KEY. */
+export function requireAdmin(key: string): void {
+  const expected = process.env.ADMIN_KEY;
+  if (!expected) {
+    throw new Error(
+      "ADMIN_KEY is not set on this deployment. Run: npx convex env set ADMIN_KEY <value>"
+    );
+  }
+  if (!timingSafeEqual(key, expected)) {
+    throw new Error("Invalid admin key");
+  }
+}

--- a/swag/convex/lib/emailTemplate.ts
+++ b/swag/convex/lib/emailTemplate.ts
@@ -1,0 +1,133 @@
+/**
+ * Renders the swag email.
+ *
+ * The same subject and body are used whether the message goes out through
+ * Resend or gets handed to the Superhuman Mail MCP server, so what you review
+ * in the outbox is exactly what the recipient receives.
+ */
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export type SwagEmailInput = {
+  recipientName: string;
+  linkUrl: string;
+  senderName: string;
+};
+
+export type RenderedEmail = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+export function renderSwagEmail({
+  recipientName,
+  linkUrl,
+  senderName,
+}: SwagEmailInput): RenderedEmail {
+  const firstName = recipientName.split(" ")[0];
+  const safeName = escapeHtml(firstName);
+  const safeLink = escapeHtml(linkUrl);
+  const safeSender = escapeHtml(senderName);
+
+  const subject = `${firstName}, your Convex swag is ready`;
+
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#ffffff;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+      One link, one order, free swag on us.
+    </div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#ffffff;">
+      <tr>
+        <td align="center" style="padding:48px 20px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#111111;">
+            <tr>
+              <td style="padding-bottom:32px;">
+                <div style="font-size:13px;letter-spacing:0.14em;text-transform:uppercase;color:#767676;">
+                  Friends of Convex
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:26px;line-height:1.3;font-weight:600;padding-bottom:20px;">
+                Thank you for being a friend of Convex
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:16px;line-height:1.65;color:#333333;padding-bottom:16px;">
+                Hey ${safeName},
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:16px;line-height:1.65;color:#333333;padding-bottom:16px;">
+                You have been around for the builds, the demos, and the late night
+                threads. Here is a small thank you. The link below is yours alone.
+                Pick your size, add your shipping address, and check out. There is
+                nothing to pay.
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 0 24px 0;">
+                <a href="${safeLink}"
+                   style="display:inline-block;background:#111111;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;padding:15px 30px;border-radius:8px;">
+                  Claim your swag
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:14px;line-height:1.6;color:#767676;padding-bottom:8px;">
+                If the button does not work, paste this into your browser:
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;line-height:1.6;padding-bottom:28px;word-break:break-all;">
+                <a href="${safeLink}" style="color:#111111;">${safeLink}</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:14px;line-height:1.6;color:#767676;padding-bottom:28px;border-top:1px solid #e6e6e6;padding-top:24px;">
+                Heads up, the link works once, so do not share it. If it has already
+                been used or something looks wrong, just reply to this email.
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:16px;line-height:1.65;color:#333333;">
+                ${safeSender}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const text = `Friends of Convex
+
+Hey ${firstName},
+
+Thank you for being a friend of Convex. You have been around for the builds, the demos, and the late night threads. Here is a small thank you.
+
+The link below is yours alone. Pick your size, add your shipping address, and check out. There is nothing to pay.
+
+${linkUrl}
+
+Heads up, the link works once, so do not share it. If it has already been used or something looks wrong, just reply to this email.
+
+${senderName}`;
+
+  return { subject, html, text };
+}

--- a/swag/convex/lib/env.ts
+++ b/swag/convex/lib/env.ts
@@ -1,0 +1,40 @@
+/**
+ * Deployment configuration read from Convex environment variables.
+ * Set these with `npx convex env set <NAME> <value>`.
+ */
+
+export type DeliveryMode = "resend" | "superhuman";
+
+/**
+ * How swag emails leave the building.
+ *
+ * - "superhuman" (default): claims queue up in the outbox and you drain them
+ *   through the Superhuman Mail MCP server, so mail comes from your own
+ *   mailbox in your own voice.
+ * - "resend": the Convex Resend component sends immediately on submit.
+ */
+export function deliveryMode(): DeliveryMode {
+  return process.env.DELIVERY_MODE === "resend" ? "resend" : "superhuman";
+}
+
+/** Signature at the bottom of the email. */
+export function senderName(): string {
+  return process.env.SENDER_NAME ?? "The Convex team";
+}
+
+/** Resend "from" header, for example: Ada <ada@example.com> */
+export function fromAddress(): string {
+  const from = process.env.EMAIL_FROM;
+  if (!from) {
+    throw new Error(
+      "EMAIL_FROM is not set. Run: npx convex env set EMAIL_FROM 'You <you@yourdomain.com>'"
+    );
+  }
+  return from;
+}
+
+/** Optional reply-to, so replies reach a human even in Resend mode. */
+export function replyToAddresses(): Array<string> {
+  const replyTo = process.env.EMAIL_REPLY_TO;
+  return replyTo ? [replyTo] : [];
+}

--- a/swag/convex/lib/env.ts
+++ b/swag/convex/lib/env.ts
@@ -6,15 +6,20 @@
 export type DeliveryMode = "resend" | "superhuman";
 
 /**
- * How swag emails leave the building.
- *
- * - "superhuman" (default): claims queue up in the outbox and you drain them
- *   through the Superhuman Mail MCP server, so mail comes from your own
- *   mailbox in your own voice.
- * - "resend": the Convex Resend component sends immediately on submit.
+ * Fallback delivery mode for a deployment that has never had the admin toggle
+ * touched. The live value is stored in the database so it can be switched
+ * without a redeploy. See settings.getDeliveryMode.
  */
-export function deliveryMode(): DeliveryMode {
+export function defaultDeliveryMode(): DeliveryMode {
   return process.env.DELIVERY_MODE === "resend" ? "resend" : "superhuman";
+}
+
+/**
+ * Resend refuses to send until both of these exist, so the admin dashboard
+ * checks before letting you switch to automatic delivery.
+ */
+export function resendConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY && process.env.EMAIL_FROM);
 }
 
 /** Signature at the bottom of the email. */
@@ -37,4 +42,29 @@ export function fromAddress(): string {
 export function replyToAddresses(): Array<string> {
   const replyTo = process.env.EMAIL_REPLY_TO;
   return replyTo ? [replyTo] : [];
+}
+
+/**
+ * Credentials for the Fourthwall Platform API.
+ *
+ * Create an API user under Settings, then For Developers, then the OpenAPI
+ * tab. That gives a username and password used with HTTP Basic auth. A bearer
+ * token is accepted too, for the OAuth flow used by multi-shop apps.
+ */
+export type FourthwallAuth =
+  | { kind: "basic"; username: string; password: string }
+  | { kind: "bearer"; token: string };
+
+export function fourthwallAuth(): FourthwallAuth | null {
+  const username = process.env.FOURTHWALL_USERNAME;
+  const password = process.env.FOURTHWALL_PASSWORD;
+  if (username && password) {
+    return { kind: "basic", username, password };
+  }
+
+  const token = process.env.FOURTHWALL_TOKEN;
+  if (token) {
+    return { kind: "bearer", token };
+  }
+  return null;
 }

--- a/swag/convex/lib/validation.ts
+++ b/swag/convex/lib/validation.ts
@@ -1,0 +1,99 @@
+/** Input normalization and validation shared by the form and the CSV import. */
+
+export const MAX_NAME_LENGTH = 80;
+export const MAX_HANDLE_LENGTH = 15;
+
+// Deliberately permissive. Real validation is the recipient clicking the link
+// in the inbox, so the goal here is only to catch obvious typos.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+const HANDLE_PATTERN = /^[A-Za-z0-9_]{1,15}$/;
+
+export function normalizeEmail(input: string): string {
+  return input.trim().toLowerCase();
+}
+
+/** Strips a leading "@" or a full profile URL down to the bare handle. */
+export function normalizeHandle(input: string): string {
+  let handle = input.trim();
+  handle = handle.replace(
+    /^https?:\/\/(www\.)?(twitter|x)\.com\//i,
+    ""
+  );
+  handle = handle.replace(/^@+/, "");
+  handle = handle.split(/[/?#]/)[0];
+  return handle.toLowerCase();
+}
+
+export function normalizeName(input: string): string {
+  return input.trim().replace(/\s+/g, " ");
+}
+
+export type ValidatedClaimInput = {
+  name: string;
+  email: string;
+  twitterHandle: string;
+  twitterHandleRaw: string;
+};
+
+/**
+ * Normalizes and validates form input.
+ * Throws with a message intended to be shown directly to the person.
+ */
+export function validateClaimInput(raw: {
+  name: string;
+  email: string;
+  twitterHandle: string;
+}): ValidatedClaimInput {
+  const name = normalizeName(raw.name);
+  if (name.length < 2) {
+    throw new Error("Please enter your name");
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    throw new Error(`Name must be ${MAX_NAME_LENGTH} characters or fewer`);
+  }
+
+  const email = normalizeEmail(raw.email);
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new Error("Please enter a valid email address");
+  }
+
+  const twitterHandle = normalizeHandle(raw.twitterHandle);
+  if (!HANDLE_PATTERN.test(twitterHandle)) {
+    throw new Error(
+      "Please enter a valid X handle, letters numbers and underscores only"
+    );
+  }
+
+  return {
+    name,
+    email,
+    twitterHandle,
+    twitterHandleRaw: raw.twitterHandle.trim(),
+  };
+}
+
+/**
+ * Pulls giveaway URLs out of pasted text or a Fourthwall CSV export.
+ * Fourthwall's export puts one link per row, but the column position and any
+ * surrounding quoting varies, so scan for URLs rather than parsing columns.
+ */
+export function extractLinks(input: string): Array<string> {
+  const matches = input.match(/https?:\/\/[^\s",;]+/g) ?? [];
+  const seen = new Set<string>();
+  const links: Array<string> = [];
+  for (const match of matches) {
+    const url = match.replace(/[.,)]+$/, "");
+    if (seen.has(url)) continue;
+    seen.add(url);
+    links.push(url);
+  }
+  return links;
+}
+
+/** Last path segment of a URL, used as the dedupe key for a giveaway link. */
+export function linkCode(url: string): string {
+  const withoutQuery = url.split(/[?#]/)[0];
+  const segments = withoutQuery.split("/").filter((s) => s.length > 0);
+  return segments[segments.length - 1] ?? url;
+}

--- a/swag/convex/lib/validation.ts
+++ b/swag/convex/lib/validation.ts
@@ -36,40 +36,55 @@ export type ValidatedClaimInput = {
   twitterHandleRaw: string;
 };
 
+export type ValidationResult =
+  | { ok: true; value: ValidatedClaimInput }
+  | { ok: false; message: string };
+
 /**
  * Normalizes and validates form input.
- * Throws with a message intended to be shown directly to the person.
+ *
+ * Returns a result rather than throwing: a mistyped email is a normal thing
+ * for a form to encounter, and throwing would log it as a server error.
+ * Messages are written to be shown to the person as is.
  */
 export function validateClaimInput(raw: {
   name: string;
   email: string;
   twitterHandle: string;
-}): ValidatedClaimInput {
+}): ValidationResult {
   const name = normalizeName(raw.name);
   if (name.length < 2) {
-    throw new Error("Please enter your name");
+    return { ok: false, message: "Please enter your name" };
   }
   if (name.length > MAX_NAME_LENGTH) {
-    throw new Error(`Name must be ${MAX_NAME_LENGTH} characters or fewer`);
+    return {
+      ok: false,
+      message: `Name must be ${MAX_NAME_LENGTH} characters or fewer`,
+    };
   }
 
   const email = normalizeEmail(raw.email);
   if (!EMAIL_PATTERN.test(email)) {
-    throw new Error("Please enter a valid email address");
+    return { ok: false, message: "Please enter a valid email address" };
   }
 
   const twitterHandle = normalizeHandle(raw.twitterHandle);
   if (!HANDLE_PATTERN.test(twitterHandle)) {
-    throw new Error(
-      "Please enter a valid X handle, letters numbers and underscores only"
-    );
+    return {
+      ok: false,
+      message:
+        "Please enter a valid X handle, letters numbers and underscores only",
+    };
   }
 
   return {
-    name,
-    email,
-    twitterHandle,
-    twitterHandleRaw: raw.twitterHandle.trim(),
+    ok: true,
+    value: {
+      name,
+      email,
+      twitterHandle,
+      twitterHandleRaw: raw.twitterHandle.trim(),
+    },
   };
 }
 

--- a/swag/convex/links.ts
+++ b/swag/convex/links.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireAdmin } from "./lib/admin";
+import { extractLinks, linkCode } from "./lib/validation";
+
+/** Import batches are chunked by the client to stay well inside limits. */
+export const MAX_LINKS_PER_IMPORT = 500;
+
+/** How many rows the stats query will scan before it reports a capped count. */
+const STATS_SCAN_LIMIT = 10000;
+
+/**
+ * Imports Fourthwall giveaway links from a pasted CSV export or a plain list.
+ * Links already present are skipped, so re-importing the same export is safe.
+ */
+export const importLinks = mutation({
+  args: {
+    key: v.string(),
+    text: v.string(),
+    batch: v.string(),
+  },
+  returns: v.object({
+    imported: v.number(),
+    duplicates: v.number(),
+    found: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const urls = extractLinks(args.text);
+    if (urls.length > MAX_LINKS_PER_IMPORT) {
+      throw new Error(
+        `Import at most ${MAX_LINKS_PER_IMPORT} links at a time, got ${urls.length}`
+      );
+    }
+
+    const batch = args.batch.trim() || "untitled";
+    const now = Date.now();
+    let imported = 0;
+    let duplicates = 0;
+
+    for (const url of urls) {
+      const code = linkCode(url);
+      const existing = await ctx.db
+        .query("giveawayLinks")
+        .withIndex("by_code", (q) => q.eq("code", code))
+        .first();
+      if (existing) {
+        duplicates++;
+        continue;
+      }
+      await ctx.db.insert("giveawayLinks", {
+        url,
+        code,
+        batch,
+        status: "available",
+        importedAt: now,
+      });
+      imported++;
+    }
+
+    return { imported, duplicates, found: urls.length };
+  },
+});
+
+export const stats = query({
+  args: { key: v.string() },
+  returns: v.object({
+    available: v.number(),
+    assigned: v.number(),
+    capped: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const available = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_status", (q) => q.eq("status", "available"))
+      .take(STATS_SCAN_LIMIT);
+    const assigned = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_status", (q) => q.eq("status", "assigned"))
+      .take(STATS_SCAN_LIMIT);
+
+    return {
+      available: available.length,
+      assigned: assigned.length,
+      capped:
+        available.length === STATS_SCAN_LIMIT ||
+        assigned.length === STATS_SCAN_LIMIT,
+    };
+  },
+});
+
+/**
+ * Deletes unclaimed links. Assigned links are never removed because a claim
+ * row points at them.
+ */
+export const clearAvailable = mutation({
+  args: { key: v.string() },
+  returns: v.object({ deleted: v.number() }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const available = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_status", (q) => q.eq("status", "available"))
+      .take(MAX_LINKS_PER_IMPORT);
+
+    for (const link of available) {
+      await ctx.db.delete(link._id);
+    }
+    return { deleted: available.length };
+  },
+});

--- a/swag/convex/links.ts
+++ b/swag/convex/links.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
 import { requireAdmin } from "./lib/admin";
 import { extractLinks, linkCode } from "./lib/validation";
 
@@ -8,6 +9,49 @@ export const MAX_LINKS_PER_IMPORT = 500;
 
 /** How many rows the stats query will scan before it reports a capped count. */
 const STATS_SCAN_LIMIT = 10000;
+
+/**
+ * Adds links to the pool, skipping any whose code is already present.
+ * Shared by the paste and CSV import and by the Fourthwall API generator.
+ */
+async function addLinks(
+  ctx: MutationCtx,
+  urls: Array<string>,
+  batch: string
+): Promise<{ imported: number; duplicates: number }> {
+  if (urls.length > MAX_LINKS_PER_IMPORT) {
+    throw new Error(
+      `Import at most ${MAX_LINKS_PER_IMPORT} links at a time, got ${urls.length}`
+    );
+  }
+
+  const label = batch.trim() || "untitled";
+  const now = Date.now();
+  let imported = 0;
+  let duplicates = 0;
+
+  for (const url of urls) {
+    const code = linkCode(url);
+    const existing = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_code", (q) => q.eq("code", code))
+      .first();
+    if (existing) {
+      duplicates++;
+      continue;
+    }
+    await ctx.db.insert("giveawayLinks", {
+      url,
+      code,
+      batch: label,
+      status: "available",
+      importedAt: now,
+    });
+    imported++;
+  }
+
+  return { imported, duplicates };
+}
 
 /**
  * Imports Fourthwall giveaway links from a pasted CSV export or a plain list.
@@ -28,38 +72,23 @@ export const importLinks = mutation({
     requireAdmin(args.key);
 
     const urls = extractLinks(args.text);
-    if (urls.length > MAX_LINKS_PER_IMPORT) {
-      throw new Error(
-        `Import at most ${MAX_LINKS_PER_IMPORT} links at a time, got ${urls.length}`
-      );
-    }
+    const result = await addLinks(ctx, urls, args.batch);
+    return { ...result, found: urls.length };
+  },
+});
 
-    const batch = args.batch.trim() || "untitled";
-    const now = Date.now();
-    let imported = 0;
-    let duplicates = 0;
-
-    for (const url of urls) {
-      const code = linkCode(url);
-      const existing = await ctx.db
-        .query("giveawayLinks")
-        .withIndex("by_code", (q) => q.eq("code", code))
-        .first();
-      if (existing) {
-        duplicates++;
-        continue;
-      }
-      await ctx.db.insert("giveawayLinks", {
-        url,
-        code,
-        batch,
-        status: "available",
-        importedAt: now,
-      });
-      imported++;
-    }
-
-    return { imported, duplicates, found: urls.length };
+/** Used by the Fourthwall action, which already has real URLs in hand. */
+export const addGenerated = internalMutation({
+  args: {
+    urls: v.array(v.string()),
+    batch: v.string(),
+  },
+  returns: v.object({
+    imported: v.number(),
+    duplicates: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    return await addLinks(ctx, args.urls, args.batch);
   },
 });
 

--- a/swag/convex/outbox.ts
+++ b/swag/convex/outbox.ts
@@ -1,0 +1,194 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireAdmin } from "./lib/admin";
+import { vChannel, vOutboxStatus } from "./schema";
+
+/**
+ * The outbox is the handoff point between this app and however you actually
+ * send mail. Resend drains it automatically. The Superhuman Mail MCP server
+ * drains it through you: your assistant reads pending rows, calls send_draft,
+ * then marks them sent.
+ */
+
+const MAX_PENDING_PAGE = 50;
+
+const vPendingEmail = v.object({
+  id: v.id("outbox"),
+  to: v.string(),
+  toName: v.string(),
+  twitterHandle: v.string(),
+  subject: v.string(),
+  html: v.string(),
+  text: v.string(),
+  linkUrl: v.string(),
+  createdAt: v.number(),
+});
+
+/** Oldest pending emails first, so nobody waits longer than they have to. */
+export const listPending = query({
+  args: {
+    key: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(vPendingEmail),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    const limit = Math.min(args.limit ?? 25, MAX_PENDING_PAGE);
+
+    const rows = await ctx.db
+      .query("outbox")
+      .withIndex("by_status_and_createdAt", (q) => q.eq("status", "pending"))
+      .order("asc")
+      .take(limit);
+
+    return rows.map((row) => ({
+      id: row._id,
+      to: row.to,
+      toName: row.toName,
+      twitterHandle: row.twitterHandle,
+      subject: row.subject,
+      html: row.html,
+      text: row.text,
+      linkUrl: row.linkUrl,
+      createdAt: row.createdAt,
+    }));
+  },
+});
+
+const vOutboxRow = v.object({
+  _id: v.id("outbox"),
+  to: v.string(),
+  toName: v.string(),
+  subject: v.string(),
+  linkUrl: v.string(),
+  status: vOutboxStatus,
+  channel: v.optional(vChannel),
+  error: v.optional(v.string()),
+  createdAt: v.number(),
+  sentAt: v.optional(v.number()),
+});
+
+export const listByStatus = query({
+  args: {
+    key: v.string(),
+    status: vOutboxStatus,
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(vOutboxRow),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    const limit = Math.min(args.limit ?? 25, MAX_PENDING_PAGE);
+
+    const rows = await ctx.db
+      .query("outbox")
+      .withIndex("by_status_and_createdAt", (q) => q.eq("status", args.status))
+      .order("desc")
+      .take(limit);
+
+    return rows.map((row) => ({
+      _id: row._id,
+      to: row.to,
+      toName: row.toName,
+      subject: row.subject,
+      linkUrl: row.linkUrl,
+      status: row.status,
+      channel: row.channel,
+      error: row.error,
+      createdAt: row.createdAt,
+      sentAt: row.sentAt,
+    }));
+  },
+});
+
+export const stats = query({
+  args: { key: v.string() },
+  returns: v.object({
+    pending: v.number(),
+    sending: v.number(),
+    sent: v.number(),
+    failed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const countByStatus = async (
+      status: "pending" | "sending" | "sent" | "failed"
+    ) => {
+      const rows = await ctx.db
+        .query("outbox")
+        .withIndex("by_status", (q) => q.eq("status", status))
+        .take(1000);
+      return rows.length;
+    };
+
+    return {
+      pending: await countByStatus("pending"),
+      sending: await countByStatus("sending"),
+      sent: await countByStatus("sent"),
+      failed: await countByStatus("failed"),
+    };
+  },
+});
+
+/**
+ * Records that an email left your mailbox. Call this straight after the
+ * Superhuman send_draft tool returns, so a rerun does not mail anyone twice.
+ */
+export const markSent = mutation({
+  args: {
+    key: v.string(),
+    ids: v.array(v.id("outbox")),
+    channel: v.optional(vChannel),
+  },
+  returns: v.object({ marked: v.number(), skipped: v.number() }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    const now = Date.now();
+    let marked = 0;
+    let skipped = 0;
+
+    for (const id of args.ids) {
+      const row = await ctx.db.get(id);
+      if (!row || row.status === "sent") {
+        skipped++;
+        continue;
+      }
+      await ctx.db.patch(id, {
+        status: "sent",
+        channel: args.channel ?? "superhuman",
+        sentAt: now,
+        error: undefined,
+      });
+      marked++;
+    }
+
+    return { marked, skipped };
+  },
+});
+
+/** Puts a row back in the queue, for example after a send failed on your end. */
+export const markPending = mutation({
+  args: {
+    key: v.string(),
+    ids: v.array(v.id("outbox")),
+  },
+  returns: v.object({ marked: v.number() }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    let marked = 0;
+    for (const id of args.ids) {
+      const row = await ctx.db.get(id);
+      if (!row) continue;
+      await ctx.db.patch(id, {
+        status: "pending",
+        error: undefined,
+        sentAt: undefined,
+        channel: undefined,
+      });
+      marked++;
+    }
+    return { marked };
+  },
+});

--- a/swag/convex/schema.ts
+++ b/swag/convex/schema.ts
@@ -1,0 +1,91 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export const vLinkStatus = v.union(
+  v.literal("available"),
+  v.literal("assigned")
+);
+
+export const vOutboxStatus = v.union(
+  v.literal("pending"),
+  v.literal("sending"),
+  v.literal("sent"),
+  v.literal("failed")
+);
+
+export const vChannel = v.union(
+  v.literal("resend"),
+  v.literal("superhuman"),
+  v.literal("manual")
+);
+
+export default defineSchema({
+  /**
+   * One row per Fourthwall giveaway link. Links are single use, so a row moves
+   * from "available" to "assigned" exactly once and is never reused.
+   */
+  giveawayLinks: defineTable({
+    url: v.string(),
+    // Trailing path segment of the URL. Used to reject duplicate imports.
+    code: v.string(),
+    // Free text label from the import, e.g. the CSV filename or campaign name.
+    batch: v.string(),
+    status: vLinkStatus,
+    assignedClaimId: v.optional(v.id("claims")),
+    assignedAt: v.optional(v.number()),
+    importedAt: v.number(),
+  })
+    .index("by_status", ["status"])
+    .index("by_code", ["code"]),
+
+  /** One row per person who filled out the form. */
+  claims: defineTable({
+    name: v.string(),
+    // Lowercased, no leading "@". The raw input is kept in twitterHandleRaw.
+    twitterHandle: v.string(),
+    twitterHandleRaw: v.string(),
+    // Lowercased and trimmed.
+    email: v.string(),
+    linkId: v.id("giveawayLinks"),
+    linkUrl: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_email", ["email"])
+    .index("by_twitterHandle", ["twitterHandle"])
+    .index("by_createdAt", ["createdAt"]),
+
+  /**
+   * Every claim enqueues exactly one outbox row. This is the single source of
+   * truth for delivery, drained either automatically by Resend or manually by
+   * an assistant connected to the Superhuman Mail MCP server.
+   */
+  outbox: defineTable({
+    claimId: v.id("claims"),
+    to: v.string(),
+    toName: v.string(),
+    twitterHandle: v.string(),
+    subject: v.string(),
+    html: v.string(),
+    text: v.string(),
+    linkUrl: v.string(),
+    status: vOutboxStatus,
+    // Which path actually delivered it. Absent until sent.
+    channel: v.optional(vChannel),
+    resendEmailId: v.optional(v.string()),
+    error: v.optional(v.string()),
+    createdAt: v.number(),
+    sentAt: v.optional(v.number()),
+  })
+    .index("by_status", ["status"])
+    .index("by_claimId", ["claimId"])
+    .index("by_resendEmailId", ["resendEmailId"])
+    .index("by_status_and_createdAt", ["status", "createdAt"]),
+
+  /** Single-row-per-key settings the admin can flip without a redeploy. */
+  config: defineTable({
+    key: v.string(),
+    boolValue: v.optional(v.boolean()),
+    stringValue: v.optional(v.string()),
+    updatedAt: v.number(),
+  }).index("by_key", ["key"]),
+});

--- a/swag/convex/settings.ts
+++ b/swag/convex/settings.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { requireAdmin } from "./lib/admin";
+
+/** Settings the admin can flip at runtime, with their defaults. */
+const BOOLEAN_DEFAULTS = {
+  // Master switch for the public form.
+  claimsOpen: true,
+  // Show the link on the confirmation screen as well as emailing it.
+  // Turn this off to make email the only way to receive a link.
+  revealLinkOnClaim: true,
+} as const;
+
+export type BooleanSettingKey = keyof typeof BOOLEAN_DEFAULTS;
+
+const vBooleanSettingKey = v.union(
+  v.literal("claimsOpen"),
+  v.literal("revealLinkOnClaim")
+);
+
+export async function getBooleanSetting(
+  ctx: QueryCtx,
+  key: BooleanSettingKey
+): Promise<boolean> {
+  const row = await ctx.db
+    .query("config")
+    .withIndex("by_key", (q) => q.eq("key", key))
+    .unique();
+  return row?.boolValue ?? BOOLEAN_DEFAULTS[key];
+}
+
+export async function setBooleanSetting(
+  ctx: MutationCtx,
+  key: BooleanSettingKey,
+  value: boolean
+): Promise<void> {
+  const row = await ctx.db
+    .query("config")
+    .withIndex("by_key", (q) => q.eq("key", key))
+    .unique();
+  if (row) {
+    await ctx.db.patch(row._id, { boolValue: value, updatedAt: Date.now() });
+    return;
+  }
+  await ctx.db.insert("config", {
+    key,
+    boolValue: value,
+    updatedAt: Date.now(),
+  });
+}
+
+/**
+ * Everything the public form needs to render. Intentionally does not expose
+ * how many links are left, only whether any remain.
+ */
+export const getPublic = query({
+  args: {},
+  returns: v.object({
+    claimsOpen: v.boolean(),
+    revealLinkOnClaim: v.boolean(),
+    linksAvailable: v.boolean(),
+  }),
+  handler: async (ctx) => {
+    const nextLink = await ctx.db
+      .query("giveawayLinks")
+      .withIndex("by_status", (q) => q.eq("status", "available"))
+      .first();
+
+    return {
+      claimsOpen: await getBooleanSetting(ctx, "claimsOpen"),
+      revealLinkOnClaim: await getBooleanSetting(ctx, "revealLinkOnClaim"),
+      linksAvailable: nextLink !== null,
+    };
+  },
+});
+
+export const setBoolean = mutation({
+  args: {
+    key: v.string(),
+    settingKey: vBooleanSettingKey,
+    value: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    await setBooleanSetting(ctx, args.settingKey, args.value);
+    return null;
+  },
+});

--- a/swag/convex/settings.ts
+++ b/swag/convex/settings.ts
@@ -2,6 +2,12 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { requireAdmin } from "./lib/admin";
+import {
+  defaultDeliveryMode,
+  fourthwallAuth,
+  resendConfigured,
+  type DeliveryMode,
+} from "./lib/env";
 
 /** Settings the admin can flip at runtime, with their defaults. */
 const BOOLEAN_DEFAULTS = {
@@ -50,6 +56,30 @@ export async function setBooleanSetting(
   });
 }
 
+const DELIVERY_MODE_KEY = "deliveryMode";
+
+export const vDeliveryMode = v.union(
+  v.literal("resend"),
+  v.literal("superhuman")
+);
+
+/**
+ * Which delivery path runs on submit. Stored in the database rather than an
+ * environment variable so it can be switched from the dashboard mid event.
+ */
+export async function getDeliveryMode(ctx: QueryCtx): Promise<DeliveryMode> {
+  const row = await ctx.db
+    .query("config")
+    .withIndex("by_key", (q) => q.eq("key", DELIVERY_MODE_KEY))
+    .unique();
+
+  return row?.stringValue === "resend"
+    ? "resend"
+    : row?.stringValue === "superhuman"
+      ? "superhuman"
+      : defaultDeliveryMode();
+}
+
 /**
  * Everything the public form needs to render. Intentionally does not expose
  * how many links are left, only whether any remain.
@@ -85,6 +115,69 @@ export const setBoolean = mutation({
   handler: async (ctx, args) => {
     requireAdmin(args.key);
     await setBooleanSetting(ctx, args.settingKey, args.value);
+    return null;
+  },
+});
+
+/**
+ * Delivery mode plus whether each path is actually usable, so the dashboard
+ * can explain why a mode is unavailable instead of failing at send time.
+ */
+export const getAdmin = query({
+  args: { key: v.string() },
+  returns: v.object({
+    deliveryMode: vDeliveryMode,
+    resendConfigured: v.boolean(),
+    fourthwallConfigured: v.boolean(),
+    senderName: v.string(),
+    fromAddress: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+    return {
+      deliveryMode: await getDeliveryMode(ctx),
+      resendConfigured: resendConfigured(),
+      fourthwallConfigured: fourthwallAuth() !== null,
+      senderName: process.env.SENDER_NAME ?? "The Convex team",
+      fromAddress: process.env.EMAIL_FROM ?? null,
+    };
+  },
+});
+
+export const setDeliveryMode = mutation({
+  args: {
+    key: v.string(),
+    mode: vDeliveryMode,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    requireAdmin(args.key);
+
+    // Switching to Resend without credentials would silently queue mail that
+    // never sends, so refuse it here where the dashboard can show why.
+    if (args.mode === "resend" && !resendConfigured()) {
+      throw new Error(
+        "Set RESEND_API_KEY and EMAIL_FROM on this deployment before switching to Resend"
+      );
+    }
+
+    const row = await ctx.db
+      .query("config")
+      .withIndex("by_key", (q) => q.eq("key", DELIVERY_MODE_KEY))
+      .unique();
+
+    if (row) {
+      await ctx.db.patch(row._id, {
+        stringValue: args.mode,
+        updatedAt: Date.now(),
+      });
+      return null;
+    }
+    await ctx.db.insert("config", {
+      key: DELIVERY_MODE_KEY,
+      stringValue: args.mode,
+      updatedAt: Date.now(),
+    });
     return null;
   },
 });

--- a/swag/convex/tsconfig.json
+++ b/swag/convex/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings are required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/swag/files.md
+++ b/swag/files.md
@@ -11,8 +11,9 @@ What each file in `swag/` does.
 | `convex/claims.ts` | `submit` assigns one link per person inside a transaction, `listRecent` feeds the admin table |
 | `convex/links.ts` | Imports Fourthwall links from CSV or pasted text, reports pool counts, clears unclaimed links |
 | `convex/outbox.ts` | The delivery queue: list pending, list by status, counts, mark sent, requeue |
-| `convex/emails.ts` | Resend client, the automatic send path, the delivery webhook handler, and retry |
-| `convex/settings.ts` | Runtime toggles read by the public page and written by the admin dashboard |
+| `convex/emails.ts` | Resend client, the automatic send path, the delivery webhook, status reconciliation, and retry |
+| `convex/fourthwall.ts` | Fourthwall Platform API client: list products, mint giveaway links into the pool |
+| `convex/settings.ts` | Delivery mode and the runtime toggles, read by the public page and written by the dashboard |
 | `convex/http.ts` | `/api/outbox/*` for the Superhuman workflow, the Resend webhook, and the SPA catch-all |
 | `convex/lib/admin.ts` | Shared secret check for admin functions |
 | `convex/lib/validation.ts` | Normalizes names, emails and X handles, and pulls URLs out of a CSV |
@@ -35,8 +36,9 @@ What each file in `swag/` does.
 | `src/components/admin/AdminPage.tsx` | Admin key gate and the tab shell |
 | `src/components/admin/OutboxPanel.tsx` | Queue counts, the Superhuman prompt, mark sent and requeue |
 | `src/components/admin/LinksPanel.tsx` | CSV upload and paste import, pool counts |
+| `src/components/admin/FourthwallGenerator.tsx` | Product picker and link generation through the Fourthwall API |
 | `src/components/admin/ClaimsPanel.tsx` | Claim list with delivery status and CSV export |
-| `src/components/admin/SettingsPanel.tsx` | Toggles for claims open and link reveal |
+| `src/components/admin/SettingsPanel.tsx` | Delivery mode picker, plus toggles for claims open and link reveal |
 | `src/components/admin/Panel.tsx` | Shared card, stat, copy block and empty state pieces |
 
 ## Config and docs

--- a/swag/files.md
+++ b/swag/files.md
@@ -1,0 +1,51 @@
+# Files
+
+What each file in `swag/` does.
+
+## Convex backend
+
+| File | Purpose |
+| --- | --- |
+| `convex/schema.ts` | Tables and indexes for `giveawayLinks`, `claims`, `outbox` and `config` |
+| `convex/convex.config.ts` | Registers the static hosting and Resend components |
+| `convex/claims.ts` | `submit` assigns one link per person inside a transaction, `listRecent` feeds the admin table |
+| `convex/links.ts` | Imports Fourthwall links from CSV or pasted text, reports pool counts, clears unclaimed links |
+| `convex/outbox.ts` | The delivery queue: list pending, list by status, counts, mark sent, requeue |
+| `convex/emails.ts` | Resend client, the automatic send path, the delivery webhook handler, and retry |
+| `convex/settings.ts` | Runtime toggles read by the public page and written by the admin dashboard |
+| `convex/http.ts` | `/api/outbox/*` for the Superhuman workflow, the Resend webhook, and the SPA catch-all |
+| `convex/lib/admin.ts` | Shared secret check for admin functions |
+| `convex/lib/validation.ts` | Normalizes names, emails and X handles, and pulls URLs out of a CSV |
+| `convex/lib/emailTemplate.ts` | Renders the HTML and plain text swag email |
+| `convex/lib/env.ts` | Reads deployment environment variables with defaults |
+
+## Frontend
+
+| File | Purpose |
+| --- | --- |
+| `src/main.tsx` | Mounts React and connects the Convex client |
+| `src/App.tsx` | Picks between the claim page and the admin dashboard by pathname |
+| `src/index.css` | Tailwind setup, theme colours, and the two animations |
+| `src/lib/utils.ts` | `cn` class name helper |
+| `src/components/ClaimPage.tsx` | Public page layout, loading skeleton, and the closed and sold out states |
+| `src/components/ClaimForm.tsx` | The three field form and its submit handling |
+| `src/components/SuccessPanel.tsx` | Confirmation screen with the link, copy button and claim button |
+| `src/components/ui/Button.tsx` | Button with variants, sizes and a loading state |
+| `src/components/ui/Field.tsx` | Labelled input with an optional prefix and hint |
+| `src/components/admin/AdminPage.tsx` | Admin key gate and the tab shell |
+| `src/components/admin/OutboxPanel.tsx` | Queue counts, the Superhuman prompt, mark sent and requeue |
+| `src/components/admin/LinksPanel.tsx` | CSV upload and paste import, pool counts |
+| `src/components/admin/ClaimsPanel.tsx` | Claim list with delivery status and CSV export |
+| `src/components/admin/SettingsPanel.tsx` | Toggles for claims open and link reveal |
+| `src/components/admin/Panel.tsx` | Shared card, stat, copy block and empty state pieces |
+
+## Config and docs
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Setup, delivery modes, Fourthwall import, deploy |
+| `SUPERHUMAN.md` | Connecting the Superhuman Mail MCP server and draining the outbox |
+| `changelog.md` | What changed and when |
+| `.env.example` | Which variables to set and where they live |
+| `vite.config.ts` | Vite with React and Tailwind, and the `@` alias |
+| `tsconfig*.json` | Strict TypeScript for the app, the Vite config, and the Convex functions |

--- a/swag/index.html
+++ b/swag/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Friends of Convex</title>
+    <meta
+      name="description"
+      content="Thank you for being friends of Convex. Claim your swag."
+    />
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/swag/package-lock.json
+++ b/swag/package-lock.json
@@ -1,0 +1,4808 @@
+{
+  "name": "friends-of-convex-swag",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "friends-of-convex-swag",
+      "version": "0.1.0",
+      "dependencies": {
+        "@convex-dev/resend": "^0.2.6",
+        "@convex-dev/static-hosting": "^0.2.1",
+        "clsx": "^2.1.1",
+        "convex": "^1.43.0",
+        "lucide-react": "^0.544.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "tailwind-merge": "^3.3.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.13",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "npm-run-all": "^4.1.5",
+        "tailwindcss": "^4.1.13",
+        "typescript": "^5.9.0",
+        "vite": "^7.1.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@convex-dev/batch-worker": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.0.tgz",
+      "integrity": "sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.36.1",
+        "react": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@convex-dev/rate-limiter": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/rate-limiter/-/rate-limiter-0.3.2.tgz",
+      "integrity": "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@convex-dev/resend": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@convex-dev/resend/-/resend-0.2.6.tgz",
+      "integrity": "sha512-TUmHezzRDtZFrsEC32c5lu5JHXlTSb7zNoaXNETKI5+X1xOrAkRT3sK/HoeWFqb/Xy42h+hqnqQWwnWpGNMiFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/rate-limiter": "^0.3.0",
+        "@convex-dev/workpool": "^0.4.6",
+        "remeda": "^2.26.0",
+        "resend": "^6.6.0",
+        "svix": "^1.70.0"
+      },
+      "peerDependencies": {
+        "convex": "^1.31.7",
+        "convex-helpers": "^0.1.106"
+      }
+    },
+    "node_modules/@convex-dev/static-hosting": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/static-hosting/-/static-hosting-0.2.1.tgz",
+      "integrity": "sha512-QMcfKUOB8dHeLa81xzk2GEIn7LzhEvtdgYhfFpIFer6uE/+xMStDxHAZsX5h1qsttYi7wNbEKAMf7MfOQ7ZrMw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "static-hosting": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "convex": "^1.37.0",
+        "react": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@convex-dev/workpool": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.9.tgz",
+      "integrity": "sha512-2EauCO+fXqhBE0qN3aC2G/CA8Udc1nDiSha2uwdJi5SaElz6HmuM3Rv60AeQ3snMZ8PdHugKKlVeEFvAhSaokQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/batch-worker": "^0.2.0"
+      },
+      "peerDependencies": {
+        "convex": "^1.36.1",
+        "convex-helpers": "^0.1.94"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convex": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+      "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esbuild": "0.27.0",
+        "prettier": "^3.0.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "convex": "bin/main.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@auth0/auth0-react": "^2.0.1",
+        "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
+        "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@auth0/auth0-react": {
+          "optional": true
+        },
+        "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex-helpers": {
+      "version": "0.1.121",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.121.tgz",
+      "integrity": "sha512-qLrAr8p3dGI59xVa4485ARaGPuBRMjKOXC56FELKVnJ5AoIHFOkjPSKR8phE3KZUxyi6eZtb54Z/MYcS+pxoAQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "convex-helpers": "bin.cjs"
+      },
+      "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "convex": "^1.43.0",
+        "hono": "^4.0.5",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "typescript": "^5.5 || ^6.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.39.0.tgz",
+      "integrity": "sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.1.tgz",
+      "integrity": "sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.99.1.tgz",
+      "integrity": "sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/swag/package.json
+++ b/swag/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "friends-of-convex-swag",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "npm-run-all --parallel dev:frontend dev:backend",
+    "dev:frontend": "vite",
+    "dev:backend": "convex dev",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "tsc -b --noEmit",
+    "deploy": "npx @convex-dev/static-hosting deploy --build --prod"
+  },
+  "dependencies": {
+    "@convex-dev/resend": "^0.2.6",
+    "@convex-dev/static-hosting": "^0.2.1",
+    "clsx": "^2.1.1",
+    "convex": "^1.43.0",
+    "lucide-react": "^0.544.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^3.3.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.13",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "npm-run-all": "^4.1.5",
+    "tailwindcss": "^4.1.13",
+    "typescript": "^5.9.0",
+    "vite": "^7.1.0"
+  }
+}

--- a/swag/src/App.tsx
+++ b/swag/src/App.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { ClaimPage } from "./components/ClaimPage";
+import { AdminPage } from "./components/admin/AdminPage";
+
+/**
+ * Two screens, so a full router would be more moving parts than it is worth.
+ * The static hosting component falls back to index.html, so /admin loads the
+ * SPA and this picks the view.
+ */
+function usePathname(): string {
+  const [pathname, setPathname] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const onPopState = () => setPathname(window.location.pathname);
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  return pathname;
+}
+
+export default function App() {
+  const pathname = usePathname();
+
+  if (pathname.startsWith("/admin")) {
+    return <AdminPage />;
+  }
+  return <ClaimPage />;
+}

--- a/swag/src/components/ClaimForm.tsx
+++ b/swag/src/components/ClaimForm.tsx
@@ -1,0 +1,112 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "convex/react";
+import { AlertCircle } from "lucide-react";
+import { api } from "../../convex/_generated/api";
+import { Button } from "./ui/Button";
+import { Field } from "./ui/Field";
+
+export type ClaimOutcome =
+  | { status: "claimed"; linkUrl: string | null; emailQueued: boolean }
+  | { status: "already_claimed"; linkUrl: string | null };
+
+type ClaimFormProps = {
+  onClaimed: (outcome: ClaimOutcome) => void;
+  onOutOfLinks: () => void;
+  onClosed: () => void;
+};
+
+export function ClaimForm({
+  onClaimed,
+  onOutOfLinks,
+  onClosed,
+}: ClaimFormProps) {
+  const submit = useMutation(api.claims.submit);
+
+  const [name, setName] = useState("");
+  const [twitterHandle, setTwitterHandle] = useState("");
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await submit({ name, email, twitterHandle });
+
+      switch (result.status) {
+        case "claimed":
+        case "already_claimed":
+          onClaimed(result);
+          break;
+        case "invalid":
+          setError(result.message);
+          break;
+        case "out_of_links":
+          onOutOfLinks();
+          break;
+        case "closed":
+          onClosed();
+          break;
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5" noValidate>
+      <Field
+        label="Your name"
+        placeholder="Ada Lovelace"
+        autoComplete="name"
+        required
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+      />
+
+      <Field
+        label="X handle"
+        prefix="@"
+        placeholder="adalovelace"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        required
+        value={twitterHandle}
+        onChange={(event) => setTwitterHandle(event.target.value)}
+      />
+
+      <Field
+        label="Email"
+        type="email"
+        placeholder="ada@example.com"
+        autoComplete="email"
+        required
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        hint="Your link is sent here. Nothing else, no list, no newsletter."
+      />
+
+      {error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-2.5 rounded-lg border border-line-bright bg-ink-soft px-3.5 py-3 text-sm text-chalk"
+        >
+          <AlertCircle className="mt-px size-4 shrink-0 text-mute" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      <Button type="submit" loading={submitting} className="mt-1 w-full">
+        {submitting ? "Sending" : "Send my link"}
+      </Button>
+    </form>
+  );
+}

--- a/swag/src/components/ClaimPage.tsx
+++ b/swag/src/components/ClaimPage.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { ClaimForm, type ClaimOutcome } from "./ClaimForm";
+import { SuccessPanel } from "./SuccessPanel";
+
+type View =
+  | { kind: "form" }
+  | { kind: "done"; outcome: ClaimOutcome }
+  | { kind: "out_of_links" }
+  | { kind: "closed" };
+
+export function ClaimPage() {
+  const settings = useQuery(api.settings.getPublic);
+  const [view, setView] = useState<View>({ kind: "form" });
+
+  const loading = settings === undefined;
+  const unavailable =
+    view.kind === "closed" ||
+    view.kind === "out_of_links" ||
+    (settings !== undefined &&
+      view.kind === "form" &&
+      (!settings.claimsOpen || !settings.linksAvailable));
+
+  return (
+    <main className="bg-halo flex min-h-dvh items-center justify-center px-5 py-14">
+      <div className="w-full max-w-[440px]">
+        <div className="mb-9 flex flex-col gap-4">
+          <div className="text-[11px] font-medium tracking-[0.18em] text-mute-dim uppercase">
+            Friends of Convex
+          </div>
+          <h1 className="text-[34px] leading-[1.12] font-semibold tracking-[-0.02em]">
+            Thank you for being
+            <br />a friend of Convex
+          </h1>
+          <p className="text-[15px] leading-relaxed text-mute">
+            You have been around for the builds, the demos, and the late night
+            threads. Drop your details and we will send you a link for some
+            swag, on us.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-line bg-ink-soft/60 p-6 backdrop-blur-sm sm:p-7">
+          {loading ? (
+            <FormSkeleton />
+          ) : unavailable ? (
+            <ClosedPanel
+              closed={view.kind === "closed" || !settings.claimsOpen}
+            />
+          ) : view.kind === "done" ? (
+            <SuccessPanel outcome={view.outcome} />
+          ) : (
+            <ClaimForm
+              onClaimed={(outcome) => setView({ kind: "done", outcome })}
+              onOutOfLinks={() => setView({ kind: "out_of_links" })}
+              onClosed={() => setView({ kind: "closed" })}
+            />
+          )}
+        </div>
+
+        <p className="mt-6 text-center text-xs text-mute-dim">
+          One link per person. Built on Convex.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function ClosedPanel({ closed }: { closed: boolean }) {
+  return (
+    <div className="animate-rise flex flex-col gap-3 py-2">
+      <h2 className="text-xl font-semibold tracking-tight">
+        {closed ? "Claims are closed" : "Every link is spoken for"}
+      </h2>
+      <p className="text-[15px] leading-relaxed text-mute">
+        {closed
+          ? "This round has wrapped up. Keep an eye on the group chat for the next one."
+          : "That was fast. All the swag has been claimed, but more may open up soon."}
+      </p>
+    </div>
+  );
+}
+
+function FormSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-5" aria-hidden="true">
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="flex flex-col gap-2">
+          <div className="h-3 w-20 rounded bg-line" />
+          <div className="h-12 rounded-xl bg-line/60" />
+        </div>
+      ))}
+      <div className="mt-1 h-12 rounded-xl bg-line" />
+    </div>
+  );
+}

--- a/swag/src/components/SuccessPanel.tsx
+++ b/swag/src/components/SuccessPanel.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { ArrowUpRight, Check, Copy, Mail } from "lucide-react";
+import { Button } from "./ui/Button";
+import type { ClaimOutcome } from "./ClaimForm";
+
+type SuccessPanelProps = {
+  outcome: ClaimOutcome;
+};
+
+export function SuccessPanel({ outcome }: SuccessPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const returning = outcome.status === "already_claimed";
+
+  async function copyLink() {
+    if (!outcome.linkUrl) return;
+    await navigator.clipboard.writeText(outcome.linkUrl);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="animate-rise flex flex-col gap-6">
+      <div className="flex size-11 items-center justify-center rounded-full border border-line-bright bg-ink-soft">
+        <Check className="size-5 text-chalk" strokeWidth={2.5} />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          {returning ? "You are already on the list" : "You are all set"}
+        </h2>
+        <p className="text-[15px] leading-relaxed text-mute">
+          {returning
+            ? "We found the link we already reserved for you. It is the same one, so check your inbox if you cannot use it here."
+            : "Your link is on its way to your inbox. It works once, so keep it to yourself."}
+        </p>
+      </div>
+
+      {outcome.linkUrl ? (
+        <div className="flex flex-col gap-3">
+          <div className="rounded-xl border border-line bg-ink-soft p-4">
+            <div className="mb-2 text-[11px] font-medium tracking-[0.14em] text-mute-dim uppercase">
+              Your link
+            </div>
+            <div className="font-mono text-[13px] break-all text-chalk">
+              {outcome.linkUrl}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              onClick={() => window.open(outcome.linkUrl ?? "", "_blank")}
+              className="flex-1"
+            >
+              Claim your swag
+              <ArrowUpRight className="size-4" />
+            </Button>
+            <Button variant="secondary" onClick={copyLink} aria-label="Copy link">
+              {copied ? (
+                <Check className="size-4" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-start gap-3 rounded-xl border border-line bg-ink-soft p-4">
+          <Mail className="mt-0.5 size-4 shrink-0 text-mute" />
+          <p className="text-sm leading-relaxed text-mute">
+            Check your inbox. If it has not landed in a few minutes, look in
+            spam before reaching out.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/swag/src/components/admin/AdminPage.tsx
+++ b/swag/src/components/admin/AdminPage.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { useConvex } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "../ui/Button";
+import { Field } from "../ui/Field";
+import { LinksPanel } from "./LinksPanel";
+import { OutboxPanel } from "./OutboxPanel";
+import { ClaimsPanel } from "./ClaimsPanel";
+import { SettingsPanel } from "./SettingsPanel";
+import { cn } from "@/lib/utils";
+
+const STORAGE_KEY = "swag-admin-key";
+
+type Tab = "outbox" | "links" | "claims" | "settings";
+
+const TABS: Array<{ id: Tab; label: string }> = [
+  { id: "outbox", label: "Outbox" },
+  { id: "links", label: "Links" },
+  { id: "claims", label: "Claims" },
+  { id: "settings", label: "Settings" },
+];
+
+export function AdminPage() {
+  const [adminKey, setAdminKey] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("outbox");
+
+  // Restore a key from a previous visit so a refresh does not lock you out.
+  const convex = useConvex();
+  useEffect(() => {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+    convex
+      .query(api.links.stats, { key: stored })
+      .then(() => setAdminKey(stored))
+      .catch(() => sessionStorage.removeItem(STORAGE_KEY));
+  }, [convex]);
+
+  if (!adminKey) {
+    return <KeyGate onUnlock={setAdminKey} />;
+  }
+
+  return (
+    <main className="min-h-dvh px-5 py-10">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[11px] font-medium tracking-[0.18em] text-mute-dim uppercase">
+              Friends of Convex
+            </div>
+            <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+              Swag control room
+            </h1>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              sessionStorage.removeItem(STORAGE_KEY);
+              setAdminKey(null);
+            }}
+          >
+            Lock
+          </Button>
+        </header>
+
+        <nav className="flex gap-1 rounded-xl border border-line bg-ink-soft p-1">
+          {TABS.map((entry) => (
+            <button
+              key={entry.id}
+              onClick={() => setTab(entry.id)}
+              className={cn(
+                "flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                tab === entry.id
+                  ? "bg-chalk text-ink"
+                  : "text-mute hover:text-chalk"
+              )}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </nav>
+
+        {tab === "outbox" ? <OutboxPanel adminKey={adminKey} /> : null}
+        {tab === "links" ? <LinksPanel adminKey={adminKey} /> : null}
+        {tab === "claims" ? <ClaimsPanel adminKey={adminKey} /> : null}
+        {tab === "settings" ? <SettingsPanel adminKey={adminKey} /> : null}
+      </div>
+    </main>
+  );
+}
+
+function KeyGate({ onUnlock }: { onUnlock: (key: string) => void }) {
+  const convex = useConvex();
+  const [value, setValue] = useState("");
+  const [checking, setChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setChecking(true);
+    setError(null);
+    try {
+      // Any admin query works as a credential check.
+      await convex.query(api.links.stats, { key: value });
+      sessionStorage.setItem(STORAGE_KEY, value);
+      onUnlock(value);
+    } catch {
+      setError("That key was not accepted");
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <main className="bg-halo flex min-h-dvh items-center justify-center px-5">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded-2xl border border-line bg-ink-soft/60 p-7"
+      >
+        <h1 className="mb-1 text-xl font-semibold tracking-tight">
+          Admin access
+        </h1>
+        <p className="mb-6 text-sm text-mute">
+          Enter the ADMIN_KEY set on this Convex deployment.
+        </p>
+
+        <Field
+          label="Admin key"
+          type="password"
+          autoComplete="current-password"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+
+        {error ? (
+          <p role="alert" className="mt-3 text-sm text-chalk">
+            {error}
+          </p>
+        ) : null}
+
+        <Button type="submit" loading={checking} className="mt-5 w-full">
+          Unlock
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/swag/src/components/admin/ClaimsPanel.tsx
+++ b/swag/src/components/admin/ClaimsPanel.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Card, EmptyState } from "./Panel";
+import { cn } from "@/lib/utils";
+
+const STATUS_STYLES: Record<string, string> = {
+  sent: "border-line-bright text-chalk",
+  pending: "border-line text-mute",
+  sending: "border-line text-mute",
+  failed: "border-chalk text-chalk",
+  unknown: "border-line text-mute-dim",
+};
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function ClaimsPanel({ adminKey }: { adminKey: string }) {
+  const claims = useQuery(api.claims.listRecent, { key: adminKey, limit: 100 });
+
+  function exportCsv() {
+    if (!claims) return;
+    const header = "name,twitter_handle,email,link,claimed_at,email_status";
+    const rows = claims.map((claim) =>
+      [
+        claim.name,
+        claim.twitterHandle,
+        claim.email,
+        claim.linkUrl,
+        new Date(claim.createdAt).toISOString(),
+        claim.emailStatus,
+      ]
+        // Quote every field so commas in names cannot break the columns.
+        .map((value) => `"${String(value).replace(/"/g, '""')}"`)
+        .join(",")
+    );
+
+    const blob = new Blob([[header, ...rows].join("\n")], {
+      type: "text/csv",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "friends-of-convex-claims.csv";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <Card
+      title={`Claims${claims ? ` (${claims.length})` : ""}`}
+      description="Everyone who filled out the form, newest first."
+    >
+      {claims === undefined ? (
+        <EmptyState>Loading</EmptyState>
+      ) : claims.length === 0 ? (
+        <EmptyState>No claims yet.</EmptyState>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            {claims.map((claim) => (
+              <div
+                key={claim._id}
+                className="flex items-center justify-between gap-4 rounded-xl border border-line bg-ink p-4"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">
+                    {claim.name}
+                    <span className="ml-2 text-mute-dim">
+                      @{claim.twitterHandle}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-xs text-mute">
+                    {claim.email}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-3">
+                  <span className="hidden text-xs text-mute-dim sm:inline">
+                    {formatDate(claim.createdAt)}
+                  </span>
+                  <span
+                    className={cn(
+                      "rounded-md border px-2 py-1 text-[11px] font-medium",
+                      STATUS_STYLES[claim.emailStatus] ?? STATUS_STYLES.unknown
+                    )}
+                  >
+                    {claim.emailStatus}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <button
+            onClick={exportCsv}
+            className="self-start text-sm text-mute underline underline-offset-4 transition-colors hover:text-chalk"
+          >
+            Export CSV
+          </button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/swag/src/components/admin/FourthwallGenerator.tsx
+++ b/swag/src/components/admin/FourthwallGenerator.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { useAction, useQuery } from "convex/react";
+import { RefreshCw, Sparkles } from "lucide-react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "../ui/Button";
+import { Field } from "../ui/Field";
+import { Card } from "./Panel";
+import { cn } from "@/lib/utils";
+
+type Product = {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+};
+
+type GenerateResult = {
+  packageId: string | null;
+  generated: number;
+  imported: number;
+  duplicates: number;
+};
+
+/**
+ * Mints giveaway links through the Fourthwall Platform API and drops them
+ * straight into the pool, so there is no CSV round trip.
+ */
+export function FourthwallGenerator({ adminKey }: { adminKey: string }) {
+  const admin = useQuery(api.settings.getAdmin, { key: adminKey });
+  const listProducts = useAction(api.fourthwall.listProducts);
+  const generateLinks = useAction(api.fourthwall.generateLinks);
+
+  const [products, setProducts] = useState<Array<Product> | null>(null);
+  const [productId, setProductId] = useState("");
+  const [count, setCount] = useState("10");
+  const [batch, setBatch] = useState("");
+  const [loadingProducts, setLoadingProducts] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [result, setResult] = useState<GenerateResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (admin && !admin.fourthwallConfigured) {
+    return (
+      <Card
+        title="Generate links from Fourthwall"
+        description="Not connected. Create an API user in Fourthwall under Settings, then For Developers, then the OpenAPI tab."
+      >
+        <pre className="overflow-x-auto rounded-xl border border-line bg-ink p-4 font-mono text-[12px] leading-relaxed text-mute">
+          {`npx convex env set FOURTHWALL_USERNAME "..."\nnpx convex env set FOURTHWALL_PASSWORD "..."`}
+        </pre>
+      </Card>
+    );
+  }
+
+  async function loadProducts() {
+    setLoadingProducts(true);
+    setError(null);
+    try {
+      const found = await listProducts({ key: adminKey });
+      setProducts(found);
+      if (found.length > 0 && !productId) {
+        setProductId(found[0].id);
+      }
+    } catch (caught) {
+      setError(readableError(caught, "Could not load products"));
+    } finally {
+      setLoadingProducts(false);
+    }
+  }
+
+  async function generate() {
+    setGenerating(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(
+        await generateLinks({
+          key: adminKey,
+          productId,
+          number: Number(count),
+          batch,
+        })
+      );
+    } catch (caught) {
+      setError(readableError(caught, "Could not generate links"));
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  const countValue = Number(count);
+  const countValid = Number.isInteger(countValue) && countValue > 0;
+
+  return (
+    <Card
+      title="Generate links from Fourthwall"
+      description="Creates real giveaway links in your shop and adds them to the pool. Fourthwall charges your card for the product and shipping when someone redeems one."
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[13px] font-medium tracking-wide text-mute">
+              Product
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              loading={loadingProducts}
+              onClick={loadProducts}
+            >
+              <RefreshCw className="size-3.5" />
+              {products ? "Refresh" : "Load products"}
+            </Button>
+          </div>
+
+          {products === null ? (
+            <div className="rounded-xl border border-dashed border-line py-6 text-center text-sm text-mute-dim">
+              Load your products to pick one
+            </div>
+          ) : products.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-line py-6 text-center text-sm text-mute-dim">
+              No products found in this shop
+            </div>
+          ) : (
+            <div className="flex max-h-64 flex-col gap-2 overflow-y-auto">
+              {products.map((product) => (
+                <button
+                  key={product.id}
+                  onClick={() => setProductId(product.id)}
+                  aria-pressed={productId === product.id}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl border p-3 text-left transition-colors",
+                    productId === product.id
+                      ? "border-chalk bg-line/30"
+                      : "border-line bg-ink hover:border-line-bright"
+                  )}
+                >
+                  {product.imageUrl ? (
+                    <img
+                      src={product.imageUrl}
+                      alt=""
+                      className="size-10 shrink-0 rounded-lg object-cover"
+                    />
+                  ) : (
+                    <div className="size-10 shrink-0 rounded-lg bg-line" />
+                  )}
+                  <span className="min-w-0 truncate text-sm">
+                    {product.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field
+            label="How many links"
+            type="number"
+            min={1}
+            max={250}
+            value={count}
+            onChange={(event) => setCount(event.target.value)}
+          />
+          <Field
+            label="Batch name"
+            placeholder="fourthwall"
+            value={batch}
+            onChange={(event) => setBatch(event.target.value)}
+          />
+        </div>
+
+        <Button
+          size="sm"
+          className="self-start"
+          loading={generating}
+          disabled={!productId || !countValid}
+          onClick={generate}
+        >
+          <Sparkles className="size-3.5" />
+          Generate {countValid ? countValue : ""} links
+        </Button>
+
+        {result ? (
+          <p className="text-sm text-mute">
+            Created {result.generated} links and added {result.imported} to the
+            pool
+            {result.duplicates > 0
+              ? `, skipping ${result.duplicates} already there`
+              : ""}
+            .{result.packageId ? ` Package ${result.packageId}.` : ""}
+          </p>
+        ) : null}
+
+        {error ? (
+          <p role="alert" className="text-sm text-chalk">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+/** Convex wraps thrown errors, so pull out just the message we threw. */
+function readableError(caught: unknown, fallback: string): string {
+  if (!(caught instanceof Error)) return fallback;
+  const match = caught.message.match(/Uncaught Error:\s*([^\n]+)/);
+  return (match?.[1] ?? caught.message.split("\n")[0] ?? fallback).trim();
+}

--- a/swag/src/components/admin/LinksPanel.tsx
+++ b/swag/src/components/admin/LinksPanel.tsx
@@ -5,6 +5,7 @@ import { api } from "../../../convex/_generated/api";
 import { Button } from "../ui/Button";
 import { Field } from "../ui/Field";
 import { Card, Stat, StatGrid } from "./Panel";
+import { FourthwallGenerator } from "./FourthwallGenerator";
 
 type ImportResult = {
   imported: number;
@@ -53,8 +54,10 @@ export function LinksPanel({ adminKey }: { adminKey: string }) {
         <Stat label="Claimed" value={stats?.assigned ?? "-"} />
       </StatGrid>
 
+      <FourthwallGenerator adminKey={adminKey} />
+
       <Card
-        title="Import giveaway links"
+        title="Or import links you already have"
         description="Upload the CSV that Fourthwall exports, or paste the column of links from your spreadsheet. Up to 500 at a time."
       >
         <div className="flex flex-col gap-4">

--- a/swag/src/components/admin/LinksPanel.tsx
+++ b/swag/src/components/admin/LinksPanel.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Upload } from "lucide-react";
+import { api } from "../../../convex/_generated/api";
+import { Button } from "../ui/Button";
+import { Field } from "../ui/Field";
+import { Card, Stat, StatGrid } from "./Panel";
+
+type ImportResult = {
+  imported: number;
+  duplicates: number;
+  found: number;
+};
+
+/**
+ * Fourthwall's giveaway page has an "Export links" button. Drop that CSV here,
+ * or paste the links straight out of the spreadsheet. Re-importing the same
+ * file is safe because links are deduped on their code.
+ */
+export function LinksPanel({ adminKey }: { adminKey: string }) {
+  const stats = useQuery(api.links.stats, { key: adminKey });
+  const importLinks = useMutation(api.links.importLinks);
+
+  const [text, setText] = useState("");
+  const [batch, setBatch] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setText(await file.text());
+    if (!batch) setBatch(file.name.replace(/\.csv$/i, ""));
+  }
+
+  async function handleImport() {
+    setImporting(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await importLinks({ key: adminKey, text, batch }));
+      setText("");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Import failed");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <StatGrid>
+        <Stat label="Available" value={stats?.available ?? "-"} />
+        <Stat label="Claimed" value={stats?.assigned ?? "-"} />
+      </StatGrid>
+
+      <Card
+        title="Import giveaway links"
+        description="Upload the CSV that Fourthwall exports, or paste the column of links from your spreadsheet. Up to 500 at a time."
+      >
+        <div className="flex flex-col gap-4">
+          <Field
+            label="Batch name"
+            placeholder="convex-friends-tees"
+            value={batch}
+            onChange={(event) => setBatch(event.target.value)}
+          />
+
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="links-text"
+              className="text-[13px] font-medium tracking-wide text-mute"
+            >
+              Links
+            </label>
+            <textarea
+              id="links-text"
+              rows={7}
+              spellCheck={false}
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              placeholder={"https://yourshop.fourthwall.com/gift/abc123\nhttps://yourshop.fourthwall.com/gift/def456"}
+              className="w-full resize-y rounded-xl border border-line bg-ink px-4 py-3 font-mono text-[13px] text-chalk transition-colors placeholder:text-mute-dim focus:border-mute focus:outline-none"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-lg border border-line-bright bg-ink-soft px-3 text-sm font-medium text-chalk transition-colors hover:border-mute">
+              <Upload className="size-3.5" />
+              Choose CSV
+              <input
+                type="file"
+                accept=".csv,text/csv,text/plain"
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) void handleFile(file);
+                }}
+              />
+            </label>
+
+            <Button
+              size="sm"
+              loading={importing}
+              disabled={text.trim().length === 0}
+              onClick={handleImport}
+            >
+              Import links
+            </Button>
+          </div>
+
+          {result ? (
+            <p className="text-sm text-mute">
+              Found {result.found}. Imported {result.imported}.{" "}
+              {result.duplicates > 0
+                ? `Skipped ${result.duplicates} already in the pool.`
+                : ""}
+            </p>
+          ) : null}
+
+          {error ? (
+            <p role="alert" className="text-sm text-chalk">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/swag/src/components/admin/OutboxPanel.tsx
+++ b/swag/src/components/admin/OutboxPanel.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Send } from "lucide-react";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { Button } from "../ui/Button";
+import { Card, CopyBlock, EmptyState, Stat, StatGrid } from "./Panel";
+
+/**
+ * The Superhuman Mail MCP server runs inside your AI client, not inside
+ * Convex, so there is no way for the backend to call it on submit. This panel
+ * is the handoff: it shows what is waiting and gives you the prompt that makes
+ * your assistant send it from your own mailbox.
+ */
+export function OutboxPanel({ adminKey }: { adminKey: string }) {
+  const stats = useQuery(api.outbox.stats, { key: adminKey });
+  const pending = useQuery(api.outbox.listPending, { key: adminKey, limit: 25 });
+  const failed = useQuery(api.outbox.listByStatus, {
+    key: adminKey,
+    status: "failed",
+    limit: 10,
+  });
+  const markSent = useMutation(api.outbox.markSent);
+  const markPending = useMutation(api.outbox.markPending);
+
+  const [busy, setBusy] = useState(false);
+
+  const apiBase = window.location.origin;
+  const assistantPrompt = `Send the pending Convex swag emails from my Superhuman account.
+
+1. GET ${apiBase}/api/outbox/pending with header "Authorization: Bearer $SWAG_ADMIN_KEY".
+2. For each email in the response, call the Superhuman send_draft tool with:
+   To: the "to" field
+   Subject: the "subject" field
+   HTML body: the "html" field, exactly as given, do not rewrite it
+3. Straight after each successful send, POST the id back so it is not sent twice:
+   POST ${apiBase}/api/outbox/sent
+   Header: Authorization: Bearer $SWAG_ADMIN_KEY
+   Body: {"ids": ["<the id>"]}
+
+Each link is single use. Never send the same id twice, and stop and tell me if a send fails.`;
+
+  async function handleMarkSent(ids: Array<Id<"outbox">>) {
+    setBusy(true);
+    try {
+      await markSent({ key: adminKey, ids, channel: "superhuman" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <StatGrid>
+        <Stat label="Pending" value={stats?.pending ?? "-"} emphasis />
+        <Stat label="Sending" value={stats?.sending ?? "-"} />
+        <Stat label="Sent" value={stats?.sent ?? "-"} />
+        <Stat label="Failed" value={stats?.failed ?? "-"} emphasis />
+      </StatGrid>
+
+      <Card
+        title="Send through Superhuman"
+        description="Paste this into an AI client connected to the Superhuman Mail MCP server. It reads the queue, sends each email from your mailbox, and marks them sent so nobody gets two links."
+      >
+        <CopyBlock text={assistantPrompt} label="Assistant prompt" />
+      </Card>
+
+      <Card
+        title={`Waiting to send${pending ? ` (${pending.length})` : ""}`}
+        description="Mark rows sent by hand if you delivered them some other way."
+      >
+        {pending === undefined ? (
+          <EmptyState>Loading</EmptyState>
+        ) : pending.length === 0 ? (
+          <EmptyState>Nothing waiting. The queue is clear.</EmptyState>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {pending.map((email) => (
+              <div
+                key={email.id}
+                className="flex items-center justify-between gap-4 rounded-xl border border-line bg-ink p-4"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">
+                    {email.toName}
+                    <span className="ml-2 text-mute-dim">
+                      @{email.twitterHandle}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-xs text-mute">
+                    {email.to}
+                  </div>
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => handleMarkSent([email.id])}
+                >
+                  <Send className="size-3.5" />
+                  Mark sent
+                </Button>
+              </div>
+            ))}
+
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={busy}
+              className="mt-2 self-start"
+              onClick={() => handleMarkSent(pending.map((email) => email.id))}
+            >
+              Mark all {pending.length} sent
+            </Button>
+          </div>
+        )}
+      </Card>
+
+      {failed && failed.length > 0 ? (
+        <Card
+          title={`Failed (${failed.length})`}
+          description="These bounced or errored. Requeue to try again."
+        >
+          <div className="flex flex-col gap-2">
+            {failed.map((row) => (
+              <div
+                key={row._id}
+                className="flex items-center justify-between gap-4 rounded-xl border border-line-bright bg-ink p-4"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{row.toName}</div>
+                  <div className="mt-0.5 truncate font-mono text-xs text-mute">
+                    {row.to}
+                  </div>
+                  {row.error ? (
+                    <div className="mt-1 truncate text-xs text-mute-dim">
+                      {row.error}
+                    </div>
+                  ) : null}
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() =>
+                    markPending({ key: adminKey, ids: [row._id] })
+                  }
+                >
+                  Requeue
+                </Button>
+              </div>
+            ))}
+          </div>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/swag/src/components/admin/Panel.tsx
+++ b/swag/src/components/admin/Panel.tsx
@@ -1,0 +1,98 @@
+import { useState, type ReactNode } from "react";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function Card({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title?: string;
+  description?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn("rounded-2xl border border-line bg-ink-soft/60 p-6", className)}
+    >
+      {title ? (
+        <h2 className="text-[15px] font-semibold tracking-tight">{title}</h2>
+      ) : null}
+      {description ? (
+        <p className="mt-1.5 text-sm leading-relaxed text-mute">{description}</p>
+      ) : null}
+      <div className={title || description ? "mt-5" : undefined}>{children}</div>
+    </section>
+  );
+}
+
+export function StatGrid({ children }: { children: ReactNode }) {
+  return <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">{children}</div>;
+}
+
+export function Stat({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: number | string;
+  emphasis?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border p-4",
+        emphasis && value !== 0
+          ? "border-line-bright bg-line/30"
+          : "border-line bg-ink-soft"
+      )}
+    >
+      <div className="text-[11px] font-medium tracking-[0.12em] text-mute-dim uppercase">
+        {label}
+      </div>
+      <div className="mt-1.5 text-2xl font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+/** Read-only block of text with a copy button, used for prompts and commands. */
+export function CopyBlock({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="relative rounded-xl border border-line bg-ink p-4">
+      {label ? (
+        <div className="mb-2 text-[11px] font-medium tracking-[0.12em] text-mute-dim uppercase">
+          {label}
+        </div>
+      ) : null}
+      <pre className="overflow-x-auto pr-10 font-mono text-[12px] leading-relaxed whitespace-pre-wrap text-mute">
+        {text}
+      </pre>
+      <button
+        onClick={copy}
+        aria-label="Copy"
+        className="absolute top-3 right-3 rounded-lg border border-line-bright p-2 text-mute transition-colors hover:text-chalk"
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      </button>
+    </div>
+  );
+}
+
+export function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-xl border border-dashed border-line py-10 text-center text-sm text-mute-dim">
+      {children}
+    </div>
+  );
+}

--- a/swag/src/components/admin/SettingsPanel.tsx
+++ b/swag/src/components/admin/SettingsPanel.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
+import { Check, Mail, UserRound } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
 import { Card } from "./Panel";
 import { cn } from "@/lib/utils";
@@ -26,57 +28,162 @@ const SETTINGS: Array<{
 
 export function SettingsPanel({ adminKey }: { adminKey: string }) {
   const settings = useQuery(api.settings.getPublic);
+  const admin = useQuery(api.settings.getAdmin, { key: adminKey });
   const setBoolean = useMutation(api.settings.setBoolean);
+  const setDeliveryMode = useMutation(api.settings.setDeliveryMode);
+
+  const [error, setError] = useState<string | null>(null);
+
+  async function chooseMode(mode: "superhuman" | "resend") {
+    setError(null);
+    try {
+      await setDeliveryMode({ key: adminKey, mode });
+    } catch {
+      setError(
+        "Set RESEND_API_KEY and EMAIL_FROM on the deployment before switching to Resend."
+      );
+    }
+  }
 
   return (
-    <Card
-      title="Settings"
-      description="Saved to the database, so changes apply immediately with no redeploy."
-    >
-      <div className="flex flex-col gap-3">
-        {SETTINGS.map((setting) => {
-          const value = settings?.[setting.key] ?? false;
-          return (
-            <div
-              key={setting.key}
-              className="flex items-start justify-between gap-5 rounded-xl border border-line bg-ink p-4"
-            >
-              <div>
-                <div className="text-sm font-medium">{setting.label}</div>
-                <p className="mt-1 text-xs leading-relaxed text-mute">
-                  {setting.description}
-                </p>
-              </div>
-              <button
-                role="switch"
-                aria-checked={value}
-                aria-label={setting.label}
-                disabled={settings === undefined}
-                onClick={() =>
-                  setBoolean({
-                    key: adminKey,
-                    settingKey: setting.key,
-                    value: !value,
-                  })
-                }
-                className={cn(
-                  "relative mt-0.5 h-6 w-11 shrink-0 rounded-full border transition-colors",
-                  value
-                    ? "border-chalk bg-chalk"
-                    : "border-line-bright bg-ink-soft"
-                )}
+    <div className="flex flex-col gap-5">
+      <Card
+        title="How emails get sent"
+        description="Both paths drain the same outbox, so switching does not change what a recipient sees."
+      >
+        <div className="grid gap-3 sm:grid-cols-2">
+          <ModeCard
+            icon={<UserRound className="size-4" />}
+            title="Superhuman"
+            blurb="Queues in the outbox. You send from your own mailbox through the Superhuman Mail MCP server."
+            detail="Comes from your real address. Needs a Business or Enterprise plan, and you have to kick off each batch."
+            selected={admin?.deliveryMode === "superhuman"}
+            ready
+            onSelect={() => chooseMode("superhuman")}
+          />
+          <ModeCard
+            icon={<Mail className="size-4" />}
+            title="Resend"
+            blurb="Sends automatically the moment someone submits the form."
+            detail={
+              admin?.resendConfigured
+                ? `Sends from ${admin.fromAddress ?? "your verified domain"}.`
+                : "Not connected. Set RESEND_API_KEY and EMAIL_FROM, using a domain you can add DNS records to."
+            }
+            selected={admin?.deliveryMode === "resend"}
+            ready={admin?.resendConfigured ?? false}
+            onSelect={() => chooseMode("resend")}
+          />
+        </div>
+
+        {error ? (
+          <p role="alert" className="mt-3 text-sm text-chalk">
+            {error}
+          </p>
+        ) : null}
+
+        <p className="mt-4 text-xs leading-relaxed text-mute-dim">
+          Signing off as {admin?.senderName ?? "..."}. Change that with
+          {" "}
+          <code className="font-mono">npx convex env set SENDER_NAME</code>.
+        </p>
+      </Card>
+
+      <Card title="Claim form">
+        <div className="flex flex-col gap-3">
+          {SETTINGS.map((setting) => {
+            const value = settings?.[setting.key] ?? false;
+            return (
+              <div
+                key={setting.key}
+                className="flex items-start justify-between gap-5 rounded-xl border border-line bg-ink p-4"
               >
-                <span
+                <div>
+                  <div className="text-sm font-medium">{setting.label}</div>
+                  <p className="mt-1 text-xs leading-relaxed text-mute">
+                    {setting.description}
+                  </p>
+                </div>
+                <button
+                  role="switch"
+                  aria-checked={value}
+                  aria-label={setting.label}
+                  disabled={settings === undefined}
+                  onClick={() =>
+                    setBoolean({
+                      key: adminKey,
+                      settingKey: setting.key,
+                      value: !value,
+                    })
+                  }
                   className={cn(
-                    "absolute top-1/2 size-4 -translate-y-1/2 rounded-full transition-all",
-                    value ? "left-6 bg-ink" : "left-1 bg-mute"
+                    "relative mt-0.5 h-6 w-11 shrink-0 rounded-full border transition-colors",
+                    value
+                      ? "border-chalk bg-chalk"
+                      : "border-line-bright bg-ink-soft"
                   )}
-                />
-              </button>
-            </div>
-          );
-        })}
+                >
+                  <span
+                    className={cn(
+                      "absolute top-1/2 size-4 -translate-y-1/2 rounded-full transition-all",
+                      value ? "left-6 bg-ink" : "left-1 bg-mute"
+                    )}
+                  />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function ModeCard({
+  icon,
+  title,
+  blurb,
+  detail,
+  selected,
+  ready,
+  onSelect,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  blurb: string;
+  detail: string;
+  selected: boolean;
+  ready: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={cn(
+        "flex flex-col gap-2 rounded-xl border p-4 text-left transition-colors",
+        selected
+          ? "border-chalk bg-line/30"
+          : "border-line bg-ink hover:border-line-bright",
+        !ready && !selected && "opacity-60"
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {icon}
+          {title}
+        </div>
+        {selected ? (
+          <span className="flex items-center gap-1 text-[11px] font-medium text-chalk">
+            <Check className="size-3" />
+            Active
+          </span>
+        ) : ready ? null : (
+          <span className="text-[11px] text-mute-dim">Not connected</span>
+        )}
       </div>
-    </Card>
+      <p className="text-xs leading-relaxed text-mute">{blurb}</p>
+      <p className="text-xs leading-relaxed text-mute-dim">{detail}</p>
+    </button>
   );
 }

--- a/swag/src/components/admin/SettingsPanel.tsx
+++ b/swag/src/components/admin/SettingsPanel.tsx
@@ -1,0 +1,82 @@
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import { Card } from "./Panel";
+import { cn } from "@/lib/utils";
+
+type SettingKey = "claimsOpen" | "revealLinkOnClaim";
+
+const SETTINGS: Array<{
+  key: SettingKey;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "claimsOpen",
+    label: "Claims are open",
+    description:
+      "Turn this off to close the form without taking the site down.",
+  },
+  {
+    key: "revealLinkOnClaim",
+    label: "Show the link on screen",
+    description:
+      "On, people see their link right after submitting and still get the email. Off, email is the only way to receive it, which matters more if you are draining the queue by hand.",
+  },
+];
+
+export function SettingsPanel({ adminKey }: { adminKey: string }) {
+  const settings = useQuery(api.settings.getPublic);
+  const setBoolean = useMutation(api.settings.setBoolean);
+
+  return (
+    <Card
+      title="Settings"
+      description="Saved to the database, so changes apply immediately with no redeploy."
+    >
+      <div className="flex flex-col gap-3">
+        {SETTINGS.map((setting) => {
+          const value = settings?.[setting.key] ?? false;
+          return (
+            <div
+              key={setting.key}
+              className="flex items-start justify-between gap-5 rounded-xl border border-line bg-ink p-4"
+            >
+              <div>
+                <div className="text-sm font-medium">{setting.label}</div>
+                <p className="mt-1 text-xs leading-relaxed text-mute">
+                  {setting.description}
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={value}
+                aria-label={setting.label}
+                disabled={settings === undefined}
+                onClick={() =>
+                  setBoolean({
+                    key: adminKey,
+                    settingKey: setting.key,
+                    value: !value,
+                  })
+                }
+                className={cn(
+                  "relative mt-0.5 h-6 w-11 shrink-0 rounded-full border transition-colors",
+                  value
+                    ? "border-chalk bg-chalk"
+                    : "border-line-bright bg-ink-soft"
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute top-1/2 size-4 -translate-y-1/2 rounded-full transition-all",
+                    value ? "left-6 bg-ink" : "left-1 bg-mute"
+                  )}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/swag/src/components/ui/Button.tsx
+++ b/swag/src/components/ui/Button.tsx
@@ -1,0 +1,54 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Variant = "primary" | "secondary" | "ghost";
+type Size = "sm" | "md";
+
+const VARIANTS: Record<Variant, string> = {
+  primary:
+    "bg-chalk text-ink hover:bg-white disabled:hover:bg-chalk shadow-[0_1px_0_rgba(255,255,255,0.4)_inset]",
+  secondary:
+    "bg-ink-soft text-chalk border border-line-bright hover:border-mute hover:bg-line/40",
+  ghost: "text-mute hover:text-chalk hover:bg-line/50",
+};
+
+const SIZES: Record<Size, string> = {
+  sm: "h-9 px-3 text-sm rounded-lg",
+  md: "h-12 px-5 text-[15px] rounded-xl",
+};
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  size?: Size;
+  loading?: boolean;
+  children: ReactNode;
+};
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  className,
+  children,
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      disabled={disabled || loading}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 font-medium",
+        "transition-all duration-150 active:scale-[0.99]",
+        "disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100",
+        VARIANTS[variant],
+        SIZES[size],
+        className
+      )}
+    >
+      {loading ? <Loader2 className="size-4 animate-spin" /> : null}
+      {children}
+    </button>
+  );
+}

--- a/swag/src/components/ui/Field.tsx
+++ b/swag/src/components/ui/Field.tsx
@@ -1,0 +1,63 @@
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+type FieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  label: string;
+  hint?: ReactNode;
+  /** Rendered inside the input, before the text. Used for the "@" on handles. */
+  prefix?: string;
+};
+
+export function Field({
+  label,
+  hint,
+  prefix,
+  className,
+  ...props
+}: FieldProps) {
+  const id = useId();
+  const hintId = `${id}-hint`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor={id}
+        className="text-[13px] font-medium tracking-wide text-mute"
+      >
+        {label}
+      </label>
+
+      <div
+        className={cn(
+          "flex items-center rounded-xl border border-line bg-ink-soft",
+          "transition-colors duration-150",
+          "focus-within:border-mute focus-within:bg-[#101010]"
+        )}
+      >
+        {prefix ? (
+          <span className="pl-4 text-[15px] text-mute-dim select-none">
+            {prefix}
+          </span>
+        ) : null}
+        <input
+          {...props}
+          id={id}
+          aria-describedby={hint ? hintId : undefined}
+          className={cn(
+            "h-12 w-full bg-transparent text-[15px] text-chalk",
+            "placeholder:text-mute-dim focus:outline-none",
+            prefix ? "pl-1 pr-4" : "px-4",
+            className
+          )}
+        />
+      </div>
+
+      {hint ? (
+        <p id={hintId} className="text-xs text-mute-dim">
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/swag/src/index.css
+++ b/swag/src/index.css
@@ -1,0 +1,73 @@
+@import "tailwindcss";
+
+@theme {
+  --color-ink: #050505;
+  --color-ink-soft: #0c0c0c;
+  --color-line: #1f1f1f;
+  --color-line-bright: #333333;
+  --color-chalk: #fafafa;
+  --color-mute: #8b8b8b;
+  --color-mute-dim: #5c5c5c;
+
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, monospace;
+}
+
+@layer base {
+  html {
+    background-color: var(--color-ink);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    margin: 0;
+    background-color: var(--color-ink);
+    color: var(--color-chalk);
+    font-family: var(--font-sans);
+  }
+
+  /* Keyboard focus stays visible, pointer focus does not add noise. */
+  :focus-visible {
+    outline: 2px solid var(--color-chalk);
+    outline-offset: 2px;
+  }
+
+  ::selection {
+    background: var(--color-chalk);
+    color: var(--color-ink);
+  }
+}
+
+@layer utilities {
+  /* Soft vignette behind the card so the page is not a flat black rectangle. */
+  .bg-halo {
+    background-image: radial-gradient(
+      60rem 40rem at 50% -10%,
+      rgba(255, 255, 255, 0.07),
+      transparent 70%
+    );
+  }
+
+  .animate-rise {
+    animation: rise 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-rise {
+    animation: none;
+  }
+}

--- a/swag/src/lib/utils.ts
+++ b/swag/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: Array<ClassValue>): string {
+  return twMerge(clsx(inputs));
+}

--- a/swag/src/main.tsx
+++ b/swag/src/main.tsx
@@ -1,0 +1,24 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { getConvexUrl } from "@convex-dev/static-hosting";
+import App from "./App";
+import "./index.css";
+
+// When served from Convex static hosting the backend URL is derivable from the
+// .convex.site hostname, so no build-time env var is required in production.
+const convexUrl = import.meta.env.VITE_CONVEX_URL ?? getConvexUrl();
+const convex = new ConvexReactClient(convexUrl);
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <ConvexProvider client={convex}>
+      <App />
+    </ConvexProvider>
+  </StrictMode>
+);

--- a/swag/src/vite-env.d.ts
+++ b/swag/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CONVEX_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/swag/tsconfig.app.json
+++ b/swag/tsconfig.app.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/swag/tsconfig.json
+++ b/swag/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/swag/tsconfig.node.json
+++ b/swag/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/swag/vite.config.ts
+++ b/swag/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(import.meta.dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A single page app for handing out free swag. People fill in name, X handle and email, the app assigns them one Fourthwall giveaway link from a pool, and emails it to them from you.

Everything lives in a new `swag/` directory with its own Convex deployment and its own dependencies. The existing notes0 app is untouched apart from one pointer line in the root README.

## Fourthwall API

Links can now be minted through the API instead of exported as a CSV. Load your products in the Links tab, pick one, choose a count, and the links land in the pool in one step.

```
POST https://api.fourthwall.com/open-api/v1.0/giveaway-links
{ "productId": "<uuid>", "number": 10 }
```

Basic auth with the API user from Settings, then For Developers, then the OpenAPI tab. A bearer token is supported for multi-shop OAuth apps. Request and response shapes come from Fourthwall's published OpenAPI spec rather than guesswork, and the client was exercised against the live API, so the URL, Basic auth encoding and error handling are verified. Only the success response parsing is untested, since that needs a real shop.

CSV import still works and both paths dedupe against each other, so nothing gets added twice.

## Delivery: both, with a toggle

Superhuman and Resend are picked in the dashboard and stored in the database, so the mode can change mid event without a redeploy. Both drain the same outbox and produce the same email.

**The thing that usually decides it:** Resend can only send from a domain you verify with DNS records, so it cannot send as `you@gmail.com`. Superhuman connects to the Gmail or Outlook account itself, so mail comes from your real everyday address. Superhuman needs a Business or Enterprise plan with Ask AI, and it authenticates a person in an AI client over OAuth rather than a backend holding a key, which is why the Convex backend cannot call it on submit. `SUPERHUMAN.md` has the runbook.

Switching to Resend is refused until `RESEND_API_KEY` and `EMAIL_FROM` are set, since queuing mail that can never send is worse than refusing the switch.

## A real bug this surfaced

Testing in Resend mode with an invalid API key reported the email as **sent**. `resend.sendEmail` only enqueues into a workpool, so a successful call means accepted, not delivered, and a 401 from Resend arrived later with nothing watching for it.

Rows now stay in **sending** until their fate is known, resolved by the delivery webhook or by a scheduled check that asks the Resend component directly. The second path exists so the dashboard stays honest on a deployment with no webhook.

That fix needed a second fix: the component reports some terminal failures through `status.status` without setting the matching boolean flag, so failed emails were being rescheduled forever instead of marked failed. Both are covered now, and an invalid key surfaces the real Resend error in the failed list.

## Correctness

- Link assignment happens in one Convex mutation. Mutations are serializable transactions, so simultaneous submissions cannot be handed the same link
- Repeat submissions return the original link instead of burning a second one, deduped on email and X handle after normalizing, so `@Ada`, `ada` and `https://x.com/ada` are one person
- Marking outbox rows sent is idempotent, so replaying a request reports skipped instead of resending
- Validation returns a result rather than throwing, so a mistyped email renders in the form instead of logging a server error
- Admin access is a shared secret (`ADMIN_KEY`), since the claim form is deliberately anonymous and there is no identity to check against

## Testing

Verified against a real local Convex backend, not mocks.

Backend: link import including comma and newline separated input, claim assignment, dedupe by email and by handle, input normalization, all three validation messages, link exhaustion, the settings toggles, the Resend switch guard, delivery mode switching, and the full send-and-reconcile cycle ending in a correctly reported failure.

Fourthwall: both endpoints reach `api.fourthwall.com` and return a clean message on rejected credentials, plus the count and admin key guards.

HTTP API: 401 with no key and with a wrong key, listing pending, the mark sent roundtrip, double-send protection reporting `skipped`, and malformed body rejection. Also fixed a stack trace leaking in the 401 response.

Browser, on both the dev server and the production build served by Convex static hosting: the claim form, success panel, already-claimed path, validation messages, mobile at 390px, the admin key gate, all four tabs, mark sent updating counts live, CSV import and duplicate detection, the delivery mode picker switching both ways, the Fourthwall panel failing gracefully on bad credentials, the settings toggles closing the public form, and `/admin` on a hard load hitting SPA fallback rather than a 404. No unexpected console errors.

## Deploying

```bash
cd swag && npm install && npx convex dev
npx convex env set ADMIN_KEY "$(openssl rand -hex 24)"
npm run deploy
```

Site and API end up on one origin at `https://<deployment>.convex.site`, with `/api` routes taking precedence over the SPA catch-all.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcedd-921e-7a28-bce1-5cb79e2bd166?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcedd-921e-7a28-bce1-5cb79e2bd166&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

